### PR TITLE
Decomp func_80048C28 (marina)

### DIFF
--- a/include/data_symbols.h
+++ b/include/data_symbols.h
@@ -15,6 +15,7 @@ extern s16 D_800EF5F0;
 
 // func_8000147C
 extern u16 D_800BE674;
+extern u16 D_801373D8;
 extern u16 D_8013747C;
 extern u16 D_80171B30[128];
 extern u16 D_80171C30[128];

--- a/src/marina.c
+++ b/src/marina.c
@@ -8,7 +8,35 @@
 
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048BB0.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048C28.s")
+u32 func_80048C28(s32 arg0) {
+    u16 flags;
+    u32 result;
+
+    if ((arg0 == 0) && ((D_801373D8 & 0x33) == 0)) {
+        return 0xFF;
+    }
+
+    flags = D_801373D8;
+    result = 4;
+
+    if (flags & 0x10) {
+        if (flags & 3) {
+            result = 6;
+        } else {
+            result = 8;
+        }
+    }
+
+    if (flags & 0x20) {
+        if (flags & 3) {
+            result = 2;
+        } else {
+            result = 0;
+        }
+    }
+
+    return result;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048C94.s")
 


### PR DESCRIPTION
Removes the old #pragma GLOBAL_ASM for the function and deletes the corresponding nonmatching ASM file.
Implements func_80048C28 in C, matching the behavior of the original MIPS.
Adds an extern u16 D_801373D8 to include/data_symbols.h to expose the global used by this function.