### PR TITLE
Decompile func_80048C94 (marina)

### DIFF
--- a/src/marina.c
+++ b/src/marina.c
@@ -1,5 +1,8 @@
 #include "common.h"
 
+extern s32 D_800D5794[];
+extern f32 D_800EF630;
+
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048600.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_800486F4.s")
@@ -10,7 +13,9 @@
 
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048C28.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048C94.s")
+s32 func_80048C94(s32 index) {
+    return (s32)((f32)D_800D5794[index] * D_800EF630);
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/marina/func_80048CE4.s")
 

--- a/versions/us1/mischiefmakers.yaml
+++ b/versions/us1/mischiefmakers.yaml
@@ -97,7 +97,7 @@ segments:
       - [0x027F70, asm] # has to do with on screen text
       - [0x0438E0, asm]
       - [0x048A30, asm]
-      - [0x049200, asm, marina]
+      - [0x049200, c, marina] # marina code segment
       - [0x04FEB0, asm]
       - [0x059EA0, asm]
       - [0x05D120, asm]


### PR DESCRIPTION
Function is a small leaf routine (index → int → float multiply → truncate back to int).
C output compiles cleanly and emits an instruction-for-instruction match against the original ASM.
Matching was verified via objdump comparison (same instruction order and control flow; only expected register allocation differences).