### PR TITLE
Decompile 1F1E0, first pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mischief Makers
-[![Total Matching](https://img.shields.io/badge/Total%20Matching-10.56%25-brightgreen.svg)]()
-[![Main Code Segment](https://img.shields.io/badge/Main%20Code%20Segment-23.53%25-yellow.svg)]()
+[![Total Matching](https://img.shields.io/badge/Total%20Matching-10.92%25-brightgreen.svg)]()
+[![Main Code Segment](https://img.shields.io/badge/Main%20Code%20Segment-24.45%25-yellow.svg)]()
 [![Overlays](https://img.shields.io/badge/Overlays-2.37%25-orange.svg)]()
 
 A in-progress decompilation of Mischief Makers (or Yuke-Yuke!! Trouble Makers, ゆけゆけ!!トラブルメーカーズ, Yuke Yuke!! Toraburu Mēkāzu in Japanese.)

--- a/include/actor.h
+++ b/include/actor.h
@@ -19,7 +19,7 @@ typedef union {
 typedef struct {
     /* 0x000 */ Mtx matrices[2]; // see A540: `actor + (gCurrentFramebufferIndex << 6)` before guTranslate/guScale/guRotate
     /* 0x080 */ s32 flags; // see func_8001751C and func_8001E2D0
-    /* 0x084 */ s16 unk_084;
+    /* 0x084 */ u16 unk_084;
     /* 0x086 */ u8 unk_086[0x2];
     /* 0x088 */ FixedCoord posX; // see func_8007F9E0 and child position setup for Q16.16-style fixed coordinates
     /* 0x08C */ FixedCoord posY;

--- a/include/common.h
+++ b/include/common.h
@@ -49,7 +49,7 @@ extern u16 gFramesInScene;
 extern u16 gGamePaused;
 extern u16 gGameState;
 extern u16 gGameStateSubState;
-extern u16 gDebugBitfeild;
+extern u16 gDebugBitfield;
 
 extern u32 gFramesInPlayTime;
 

--- a/include/cosine.h
+++ b/include/cosine.h
@@ -9,12 +9,12 @@ extern f32 gCosineLookup[1024];
 //there is a second float table in the game that goes unused.
 extern f32 gUnusedFloatTable[512];
 
-#define COSLEN ((sizeof(gCosineLookup)/sizeof(f32))-1)
-#define COSPiOver2 ((sizeof(gCosineLookup)/sizeof(f32))/4)
-#define RadStep (f64)360.0/(sizeof(gCosineLookup)/sizeof(f32))// = 0.3515625. used for sin/cos lookups
-#define COS(x) gCosineLookup[x&COSLEN]
-#define SIN(x) gCosineLookup[x-COSPiOver2&COSLEN] //cos(x-pi/2)=sin(x)
-#define NEGSIN(x) gCosineLookup[x+COSPiOver2&COSLEN]//cos(x+pi/2)=-sin(x)
+#define COSLEN (ARRAYLENGTH(gCosineLookup) - 1)
+#define COSPiOver2 (ARRAYLENGTH(gCosineLookup) / 4)
+#define RadStep (f64)360.0/(ARRAYLENGTH(gCosineLookup)) // = 0.3515625. used for sin/cos lookups
+#define COS(x) gCosineLookup[(x) & COSLEN]
+#define SIN(x) gCosineLookup[((x) - COSPiOver2) & COSLEN] //cos(x-pi/2)=sin(x)
+#define NEGSIN(x) gCosineLookup[((x) + COSPiOver2) & COSLEN] //cos(x+pi/2)=-sin(x)
 
 #endif
 

--- a/include/music.h
+++ b/include/music.h
@@ -23,4 +23,10 @@ typedef struct {
     /* 0x06 */ u16 unk_3842[11];
 } AudioBufferSampleCounts; /* size = 0x1C */
 
+extern s16 D_800EF4D4;
+extern s16 gMusicVolume;
+extern u16 gSfxPlayerVolumes[];
+extern u8 gSfxPlayerFlags[];
+extern u16 gSfxSequenceIds[];
+
 #endif

--- a/src/1F1E0.c
+++ b/src/1F1E0.c
@@ -97,8 +97,8 @@ extern void func_8008C528(u16); // guess
 extern void func_8008CA90(void);
 
 // quantizes NEGSIN to `n` number of angles
-#define UPPER_N_BITS(n, s) (((1 << ((n)/2)) - 1) << ((s) - ((n)/2)))
-#define NEGSIN_QUANTIZE(x, n) gCosineLookup[(((x)+COSPiOver2) & UPPER_N_BITS(n, 10)) & 0x3FF]
+#define UPPER_N_BITS(n, s) (((1 << ((n) / 2)) - 1) << ((s) - ((n) / 2)))
+#define NEGSIN_QUANTIZE(x, n) gCosineLookup[(((x) + COSPiOver2) & UPPER_N_BITS(n, 10)) & COSLEN]
 
 s32 func_8001E5E0(u16 arg0, u16 arg1, s32 arg2) {
     s32 v;
@@ -106,7 +106,7 @@ s32 func_8001E5E0(u16 arg0, u16 arg1, s32 arg2) {
 
     sp20 = sqrtf(gActors[arg0].unk_0E2);
     v = func_800294E0(gActors[arg0].posX.raw - gActors[arg1].posX.raw, gActors[arg0].posY.raw - gActors[arg1].posY.raw);
-    return (s32) (NEGSIN_QUANTIZE(v, 2) * (sp20 * arg2 * 2));
+    return NEGSIN_QUANTIZE(v, 2) * (sp20 * arg2 * 2);
 }
 
 s32 func_8001E6F4(u16 arg0, u16 arg1, s32 arg2) {
@@ -115,7 +115,7 @@ s32 func_8001E6F4(u16 arg0, u16 arg1, s32 arg2) {
 
     sp20 = sqrtf(gActors[arg0].unk_0E2);
     v = func_800294E0(gActors[arg0].posX.raw - gActors[arg1].posX.raw, gActors[arg0].posY.raw - gActors[arg1].posY.raw);
-    return (s32) (SIN(v) * (sp20 * arg2 * 2));
+    return SIN(v) * (sp20 * arg2 * 2);
 }
 
 void func_8001E808(s32 arg0, s32 arg1) {
@@ -387,8 +387,6 @@ void func_800208D4(void) {
     gGamePaused = 0;
 }
 
-#ifdef NON_MATCHING
-// https://decomp.me/scratch/nLKMi
 void func_8002092C(void) {
     u16 index;
 
@@ -402,19 +400,15 @@ void func_8002092C(void) {
         gActors[index].posX.whole = -2;
         gActors[index].posY.whole = 3;
         gActors[index].posZ.whole = 1025;
-        // could be `index-N` or `index+N`, depending on start address
-        gActors[index].unk_0AA = D_800C7CA4[index+1];
-        gActors[index].unk_0AC = D_800C7CAC[index+1];
-        gActors[index].unk_0B0 = D_800C7CB4[index+1];
-        gActors[index].unk_0AE = D_800C7CBC[index+1];
+        gActors[index].unk_0AA = D_800C7CA4[index + 0];
+        gActors[index].unk_0AC = D_800C7CAC[index + 0];
+        gActors[index].unk_0B0 = D_800C7CB4[index + 0];
+        gActors[index].unk_0AE = D_800C7CBC[index + 0];
         gActors[index].colorR = 0;
         gActors[index].colorG = 0;
         gActors[index].colorB = 0;
     }
 }
-#else
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8002092C.s")
-#endif
 
 void func_80020A54(void) {
     u16 index;

--- a/src/1F1E0.c
+++ b/src/1F1E0.c
@@ -1,67 +1,455 @@
 #include "common.h"
+#include "actor.h"
+#include "cosine.h"
+#include "boot.h"
+#include "input.h"
+#include "music.h"
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E5E0.s")
+typedef void (*UnkFunc800CA1C0)(u16, u16, Actor*);
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E6F4.s")
+extern u16 D_800BE4D0;
+extern u16 D_800BE4D4;
+extern u16 D_800BE4E0;
+extern u16 D_800BE530;
+extern u16 D_800BE534;
+extern u16 D_800BE544;
+extern u16 D_800BE6B4;
+extern u16 D_800BE6B8;
+extern u16 D_800BE704;
+extern u16 D_800BE708;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E808.s")
+extern s32 D_800CA28C; // unknown type
+extern s32 D_800CA2A0; // unknown type
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E814.s")
+// these could be related arrays
+extern s16 D_800C7CA4[];
+extern s16 D_800C7CAC[];
+extern s16 D_800C7CB4[];
+extern s16 D_800C7CBC[];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E8E4.s")
+extern UnkFunc800CA1C0 D_800CA1C0[];
+extern u16 D_800CA230;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E964.s")
+extern u16 D_800D28E4;
+extern u16 D_800D28E8;
+extern u16 D_800D2918;
+extern u16 D_800D291C;
+extern u16 D_800D2920;
+extern u16 D_800D2924;
+extern u16 D_800D2978[];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001E9DC.s")
+extern u8 D_8010CDF0[0x10000];
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001EADC.s")
+extern u16 D_8011CDF8[];
+extern u16 D_8011CF20[];
+extern u16 D_8011D048[];
+extern u16 D_8011D170[];
+extern u16 D_8011D290[];
+extern u16 D_8011D3D0[];
+extern u16 D_8011D4F0[];
+extern u16 D_8011D610[];
+extern u16 D_8011D730[];
+extern u16 D_8011D850[];
+extern u32 D_80137458;
+extern u32 D_801374DC; // time duration
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001EB8C.s")
+extern u16 D_80178136;
+extern u16 D_80178162;
+extern s16 D_801781C0[]; // some volume setting
+extern u16 D_801781C8;
+extern u16 D_801781CA;
+extern u16 D_801781CC;
+extern u16 D_801781CE;
+extern u16 D_801781D0;
+extern u16 D_801781D2;
+extern u16 D_801781D4;
+extern u16 D_801781DC;
+extern u16 D_801781E0;
+extern u16 D_801782B8;
 
+extern void func_8001107C(void);
+extern void func_800122B0(void);
+extern void func_80012830(void);
+extern void func_80014AF0(void);
+extern void func_80014C44(void);
+extern void func_80016CB4(void);
+extern void func_80016D94(void);
+extern void func_8001751C(void);
+extern u64 func_8001C7F0(u16);
+extern void func_8001DE30(void);
+extern void func_8001FF30(void);
+extern void func_8001FF50(void);
+extern void func_80022470(void);
+extern void func_800253B0(void);
+extern s32 func_800294E0(s32, s32);
+extern void func_800457C8(void);
+extern void func_80047C98(void);
+extern void func_80047CCC(void);
+extern void func_8004ED10(u16);
+extern void func_8005C8A4(void);
+extern s16 func_8005DEFC(void);
+extern void func_8005F6D4(void);
+extern void func_80083518(s32, s32, s16, s32); // guess on types
+extern void func_800836A0(s32, s32, s32*, s32); // guess on types
+extern void func_80083A74(s32, s32, s32); // guess
+extern void func_80083C54(s16, s32, s32); // guess
+extern void func_8008C528(u16); // guess
+extern void func_8008CA90(void);
+
+// quantizes NEGSIN to `n` number of angles
+#define UPPER_N_BITS(n, s) (((1 << ((n)/2)) - 1) << ((s) - ((n)/2)))
+#define NEGSIN_QUANTIZE(x, n) gCosineLookup[(((x)+COSPiOver2) & UPPER_N_BITS(n, 10)) & 0x3FF]
+
+s32 func_8001E5E0(u16 arg0, u16 arg1, s32 arg2) {
+    s32 v;
+    f32 sp20;
+
+    sp20 = sqrtf(gActors[arg0].unk_0E2);
+    v = func_800294E0(gActors[arg0].posX.raw - gActors[arg1].posX.raw, gActors[arg0].posY.raw - gActors[arg1].posY.raw);
+    return (s32) (NEGSIN_QUANTIZE(v, 2) * (sp20 * arg2 * 2));
+}
+
+s32 func_8001E6F4(u16 arg0, u16 arg1, s32 arg2) {
+    s32 v;
+    f32 sp20;
+
+    sp20 = sqrtf(gActors[arg0].unk_0E2);
+    v = func_800294E0(gActors[arg0].posX.raw - gActors[arg1].posX.raw, gActors[arg0].posY.raw - gActors[arg1].posY.raw);
+    return (s32) (SIN(v) * (sp20 * arg2 * 2));
+}
+
+void func_8001E808(s32 arg0, s32 arg1) {
+}
+
+void func_8001E814(u16 arg0, u16 arg1) {
+    if ((gActors[arg0].velocityX != 0) || (gActors[arg0].velocityY != 0)) {
+        gActors[arg1].unk_0F8 = gActors[arg0].velocityX;
+        gActors[arg1].unk_0FC = gActors[arg0].velocityY;
+    }
+    else {
+        gActors[arg1].unk_0F8 = func_8001E5E0(arg0, arg1, 0x2000);
+        gActors[arg1].unk_0FC = func_8001E6F4(arg0, arg1, 0x2000);
+    }
+}
+
+void func_8001E8E4(u16 arg0, u16 arg1) {
+    if (!(gActors[arg0].flags & 0x20)) {
+        gActors[arg1].unk_0F8 = gActors[arg0].unk_0F8;
+    }
+    else {
+        gActors[arg1].unk_0F8 = -gActors[arg0].unk_0F8;
+    }
+    gActors[arg1].unk_0FC = gActors[arg0].unk_0FC;
+}
+
+void func_8001E964(u16 arg0, u16 arg1) {
+    if (gActors[arg1].posX.whole < gActors[arg0].posX.whole) {
+        gActors[arg1].unk_0F8 = -gActors[arg0].unk_0F8;
+    }
+    else {
+        gActors[arg1].unk_0F8 = gActors[arg0].unk_0F8;
+    }
+    gActors[arg1].unk_0FC = gActors[arg0].unk_0FC;
+}
+
+void func_8001E9DC(u16 arg0, u16 arg1) {
+    gActors[arg1].unk_0F8 = gActors[arg0].unk_0F8 * COS(func_8000178C() * 4);
+    gActors[arg1].unk_0FC = gActors[arg0].unk_0FC * COS(func_8000178C());
+}
+
+void func_8001EADC(u16 arg0, u16 arg1) {
+    if ((gActors[arg1].unk_0DE == 0xB) || (gActors[arg1].unk_0DE == 0xE) || (gActors[arg1].unk_0DE == 0xF)) {
+        gActors[arg1].unk_098 &= ~0x2;
+        gActors[arg0].unk_098 ^= 0x3;
+        gActors[arg0].unk_0DC = gActors[arg0].unk_0DA;
+        gActors[arg0].unk_0DD = gActors[arg0].unk_0DB;
+    }
+    else {
+        func_8001E9DC(arg0, arg1);
+    }
+}
+
+void func_8001EB8C(u16 arg0, u16 arg1) {
+    gActors[arg1].unk_0DC = gActors[arg0].unk_0DA;
+    gActors[arg1].unk_0DD = gActors[arg0].unk_0DB;
+    D_800CA1C0[gActors[arg0].unk_0DB](arg0, arg1, gActors);
+}
+
+void func_8001EC1C(void);
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001EC1C.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001F88C.s")
+void func_8001F88C(void) {
+    u16 index; // var_a0
+
+    if (!(D_80137458 & 0x10)) {
+        for (index = 0, D_800BE4D0 = 0, D_800BE4D4 = 0; index < 144; index++) {
+            if (gActors[index].flags & 0x40000) {
+                D_8011CF20[D_800BE4D0] = index;
+                D_8011D170[D_800BE4D0] = gActors[index].posX.whole + gActors[index].unk_0AC;
+                D_8011D3D0[D_800BE4D0] = gActors[index].posX.whole + gActors[index].unk_0AA;
+                D_8011D610[D_800BE4D0] = gActors[index].posY.whole + gActors[index].unk_0AE;
+                D_8011D850[D_800BE4D0] = gActors[index].posY.whole + gActors[index].unk_0B0;
+                D_800BE4D0++;
+            }
+            if (gActors[index].flags & 0x2000) {
+                D_8011CDF8[D_800BE4D4] = index;
+                D_8011D048[D_800BE4D4] = gActors[index].posX.whole + gActors[index].unk_0AC;
+                D_8011D290[D_800BE4D4] = gActors[index].posX.whole + gActors[index].unk_0AA;
+                D_8011D4F0[D_800BE4D4] = gActors[index].posY.whole + gActors[index].unk_0AE;
+                D_8011D730[D_800BE4D4] = gActors[index].posY.whole + gActors[index].unk_0AE - 8;
+                D_800BE4D4++;
+            }
+        }
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FA78.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FCA0.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FEB0.s")
+void func_8001FEB0(void) {
+    u32 index;
+
+    for (index = 0; index < ARRAYLENGTH(D_8010CDF0); index++) {
+        if (D_8010CDF0[index] == 0x34) {
+            D_8010CDF0[index] = 0xF8;
+        }
+    }
+
+    for (index = 0; D_800D2978[index] != 0; index += 3) {
+        D_800D2978[index] &= 0xFFFF7FFF;
+    }
+}
 
 void func_8001FF28(void) {
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FF30.s")
+void func_8001FF30(void) {
+    gActors[0].unk_098 &= 0x80600;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FF50.s")
+void func_8001FF50(void) {
+    u16 index;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FFA8.s")
+    for (index = 1; index < 192; index++) {
+        gActors[index].unk_098 &= 0x380600;
+    }
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80020024.s")
+void func_8001FFA0(void) {
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8002034C.s")
+void func_8001FFA8(void) {
+    D_800CA230 = 0;
+    D_800BE704 = D_801781C8;
+    D_800BE708 = D_801781CA;
+    D_800BE544 = D_801781CC;
+    D_800D2920 = D_801781CE;
+    D_800D2924 = D_801781D0;
+    D_800D2918 = D_801781D2;
+    D_800D291C = D_801781D4;
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_800205DC.s")
+void func_80020024(void) {
+    s32 index;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_800207DC.s")
+    D_800BE4E0++;
+    D_801782B8++;
+    if ((D_801781E0 < 36000) && (D_800D28E8 >= 2) && (func_8005DEFC() == 0) && (D_800D28E4 < 97)) {
+        D_801781E0++;
+    }
+    func_800122B0();
+    if (gDebugBitfield & 0x2) {
+        if ((gButtonPress & D_800BE530) && (D_800BE6B4 != 1)) {
+            D_800BE6B4--;
+            D_801781DC = 0;
+        }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80020844.s")
+        if ((gButtonPress & D_800BE534) && (D_800BE6B4 != 50)) {
+            D_800BE6B4++;
+            D_801781DC = 0;
+        }
+        if ((gFramesInScene % D_800BE6B4) == 0) {
+            gButtonPress |= D_801781DC;
+            D_801781DC = 0;
+        }
+        else {
+            D_801781DC |= gButtonPress;
+            return;
+        }
+    }
+    func_800253B0();
+    func_8001F88C();
+    func_80014AF0();
+    func_80016CB4();
+    func_80012830();
+    func_80016D94();
+    func_8001EC1C();
+    func_8001107C();
+    if (D_800CA230 == 0) {
+        func_8004ED10(0);
+        func_8008C528(0x41);
+    }
+    func_8001FF30();
+    func_8001DE30();
+    func_8008CA90();
+    func_8001751C();
+    func_80014C44();
+    func_8005C8A4();
+    func_8001FF50();
+    func_8005F6D4();
+    func_80022470();
+    if (gGameState == GAMESTATE_GAMEPLAY) {
+        func_80047CCC();
+    }
+    func_80047C98();
+    if (gDebugBitfield & 0x4000) {
+        for (index = 0; index < 4; index++) {
+            func_80083C54(gSfxPlayerFlags[index], -144, 60 - 32 * index);
+            func_80083A74(gSfxSequenceIds[index] - 33, -144, 48 - 32 * index);
+            func_80083C54(gSfxPlayerVolumes[index], -104, 60 - 32 * index);
+        }
+    }
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_800208D4.s")
+void func_8002034C(void) {
+    u32 val;
+    u32 time_remain;
 
+    // 100 days * 24 hr/day * 60 min/hr * 60 sec/min * 60Hz = 518,400,000
+    if (gFramesInPlayTime >= 518400000) {
+        gFramesInPlayTime = 518399999;
+    }
+    time_remain = gFramesInPlayTime / 60;
+    val = time_remain % 60;
+    func_80083518(11, 0, (val / 10) + 0x51, 0);
+    func_80083518(12, 0, (val % 10) + 0x51, 0);
+    time_remain /= 60;
+    val = time_remain % 60;
+    func_80083518(8, 0, (val / 10) + 0x51, 0);
+    func_80083518(9, 0, (val % 10) + 0x51, 0);
+    time_remain /= 60;
+    val = time_remain % 24;
+    func_80083518(5, 0, (val / 10) + 0x51, 0);
+    func_80083518(6, 0, (val % 10) + 0x51, 0);
+    time_remain /= 24;
+    func_80083518(2, 0, (time_remain / 10) + 0x51, 0);
+    func_80083518(3, 0, (time_remain % 10) + 0x51, 0);
+}
+
+void func_800205DC(void) {
+    u16 val;
+
+    val = D_80178136;
+    func_80083518(6, 1, (val % 10) + 0x51, 0);
+    val /= 10;
+    func_80083518(5, 1, (val % 10) + 0x51, 0);
+    val /= 10;
+    func_80083518(4, 1, (val % 10) + 0x51, 0);
+    val /= 10;
+    func_80083518(3, 1, (val % 10) + 0x51, 0);
+}
+
+void func_800207DC(void) {
+    u64 ret;
+
+    ret = func_8001C7F0(D_80178162);
+    if (ret != 0) {
+        func_800836A0(9, 1, &D_800CA2A0, 0);
+    }
+    else {
+        func_800836A0(9, 1, &D_800CA28C, 0);
+    }
+}
+
+void func_80020844(void) {
+    u16 index;
+    u16 jndex;
+
+    for (index = 0; index < 4; index++) {
+        gSfxPlayerVolumes[index] = D_801781C0[index];
+    }
+    Sound_PlaySfx(0xCB);
+    
+    for (jndex = 204; jndex < 208; jndex++) {
+        gActors[jndex].flags = 0;
+    }
+}
+
+void func_800208D4(void) {
+    u16 index;
+
+    for (index = 200; index < 204; index++) {
+        gActors[index].flags = 0;
+    }
+    gMusicVolume = D_800EF4D4;
+    gGameStateSubState = 0;
+    gGamePaused = 0;
+}
+
+#ifdef NON_MATCHING
+// https://decomp.me/scratch/nLKMi
+void func_8002092C(void) {
+    u16 index;
+
+    for (index = 200; index < 204; index++) {
+        gActors[index].actorType = 0;
+        func_8001E2D0(index);
+        gActors[index].unk_094 |= 0x800;
+        gActors[index].flags |= 8;
+        gActors[index].unk_188 = 0;
+        gActors[index].unk_084 = 0x8000;
+        gActors[index].posX.whole = -2;
+        gActors[index].posY.whole = 3;
+        gActors[index].posZ.whole = 1025;
+        // could be `index-N` or `index+N`, depending on start address
+        gActors[index].unk_0AA = D_800C7CA4[index+1];
+        gActors[index].unk_0AC = D_800C7CAC[index+1];
+        gActors[index].unk_0B0 = D_800C7CB4[index+1];
+        gActors[index].unk_0AE = D_800C7CBC[index+1];
+        gActors[index].colorR = 0;
+        gActors[index].colorG = 0;
+        gActors[index].colorB = 0;
+    }
+}
+#else
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8002092C.s")
+#endif
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80020A54.s")
+void func_80020A54(void) {
+    u16 index;
 
+    for (index = 200; index < 204; index++) {
+        gActors[index].flags = 0;
+    }
+}
+
+void func_80020A90(void);
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80020A90.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/GameState_Gameplay.s")
+void GameState_Gameplay(void) {
+    u32 start_time;
+
+    start_time = osGetTime();
+    func_800457C8();
+    D_801374DC = osGetTime() - start_time;
+    if (gGamePaused) {
+        func_80020A90();
+    }
+    else {
+        func_80020024();
+    }
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80021098.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/GameState_Attract.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80021620.s")
+void func_80021620(void) {
+    if (gButtonPress & D_800BE534) {
+        D_800BE6B8 ^= 0xFF;
+    }
+}
 
 void func_80021658(void) {
 }
@@ -69,6 +457,8 @@ void func_80021658(void) {
 void func_80021660(void) {
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80021668.s")
+void func_80021668(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
+}
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8002167C.s")
+void func_8002167C(void) {
+}

--- a/src/1F1E0.c
+++ b/src/1F1E0.c
@@ -9,7 +9,10 @@ typedef void (*UnkFunc800CA1C0)(u16, u16, Actor*);
 
 extern u16 D_800BE4D0;
 extern u16 D_800BE4D4;
+extern u16 D_800BE4D8;
+extern u16 D_800BE4DC;
 extern u16 D_800BE4E0;
+extern u16 D_800BE500;
 extern u16 D_800BE530;
 extern u16 D_800BE534;
 extern u16 D_800BE544;
@@ -29,6 +32,15 @@ extern s16 D_800C7CBC[];
 
 extern UnkFunc800CA1C0 D_800CA1C0[];
 extern u16 D_800CA230;
+extern u16 D_800CA238;
+extern u16 D_800CA23C;
+extern u16 D_800CA240;
+extern u16 D_800CA244;
+extern u16 D_800CA248;
+extern u16 D_800CA24C;
+extern u16 D_800CA250;
+extern u16* D_800CBDFC[];
+extern u16* D_800CBE0C[];
 
 extern u16 D_800D28E4;
 extern u16 D_800D28E8;
@@ -38,18 +50,18 @@ extern u16 D_800D2920;
 extern u16 D_800D2924;
 extern u16 D_800D2978[];
 
+extern u16 D_80104098[];
 extern u8 D_8010CDF0[0x10000];
-
 extern u16 D_8011CDF8[];
 extern u16 D_8011CF20[];
-extern u16 D_8011D048[];
-extern u16 D_8011D170[];
-extern u16 D_8011D290[];
-extern u16 D_8011D3D0[];
-extern u16 D_8011D4F0[];
-extern u16 D_8011D610[];
-extern u16 D_8011D730[];
-extern u16 D_8011D850[];
+extern s16 D_8011D048[];
+extern s16 D_8011D170[];
+extern s16 D_8011D290[];
+extern s16 D_8011D3D0[];
+extern s16 D_8011D4F0[];
+extern s16 D_8011D610[];
+extern s16 D_8011D730[];
+extern s16 D_8011D850[];
 extern u32 D_80137458;
 extern u32 D_801374DC; // time duration
 
@@ -70,6 +82,7 @@ extern u16 D_801782B8;
 extern void func_8001107C(void);
 extern void func_800122B0(void);
 extern void func_80012830(void);
+extern u8 func_80012AB4(s16 arg0, s16 arg1);
 extern void func_80014AF0(void);
 extern void func_80014C44(void);
 extern void func_80016CB4(void);
@@ -86,6 +99,7 @@ extern void func_800457C8(void);
 extern void func_80047C98(void);
 extern void func_80047CCC(void);
 extern void func_8004ED10(u16);
+extern u8 func_8005C870(u8);
 extern void func_8005C8A4(void);
 extern s16 func_8005DEFC(void);
 extern void func_8005F6D4(void);
@@ -203,9 +217,69 @@ void func_8001F88C(void) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FA78.s")
+u8 func_8001FA78(u16 arg0, s16 arg1, s16 arg2) {
+    u16 var_a3;
+    u16 index;
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_8001FCA0.s")
+    var_a3 = arg0;
+    if ((gActors[arg0].flags & 0x02000000) || (gActors[arg0].unk_098 & 0x600)) {
+        var_a3 = gActors[arg0].unk_0D6;
+    }
+    
+    for (index = 0; index < D_800BE4D0; index++) {
+        if ((arg0 != D_8011CF20[index]) && (var_a3 != D_8011CF20[index]) &&
+            (D_8011D170[index] >= arg1) && (arg1 >= D_8011D3D0[index]) &&
+            (D_8011D610[index] >= arg2) && (arg2 >= D_8011D850[index])) {
+            D_800BE4DC = D_8011CF20[index];
+            return 0xC0;
+        }
+    }
+
+    for (index = 0; index < D_800BE4D4; index++) {
+        if ((arg0 != D_8011CDF8[index]) && (var_a3 != D_8011CDF8[index]) &&
+            (D_8011D048[index] >= arg1) && (arg1 >= D_8011D290[index]) &&
+            (D_8011D4F0[index] >= arg2) && (arg2 >= D_8011D730[index])) {
+            D_800BE4DC = D_8011CDF8[index];
+            return 0x40;
+        }
+    }
+
+    D_800BE4DC = 0;
+    return 0;
+}
+
+u8 func_8001FCA0(u16 arg0, s16 arg1, s16 arg2) {
+    u8 temp_v0;
+    u16 index;
+
+    temp_v0 = func_8005C870(func_80012AB4(arg1, arg2));
+    D_800BE4DC = 0;
+    D_800BE4D8 = 0;
+    if (temp_v0 != 0) {
+        return temp_v0;
+    }
+    for (index = 0; index < D_800BE4D0; index++) {
+        if ((D_8011D170[index] >= arg1) && (arg1 >= D_8011D3D0[index]) &&
+            (D_8011D610[index] >= arg2) && (arg2 >= D_8011D850[index]) &&
+            (arg0 != D_8011CF20[index])) {
+            D_800BE4DC = D_8011CF20[index];
+            D_800BE4D8 = 1;
+            return 0xC0;
+        }
+    }
+
+    for (index = 0; index < D_800BE4D4; index++) {
+        if ((D_8011D048[index] >= arg1) && (arg1 >= D_8011D290[index]) &&
+            (D_8011D4F0[index] >= arg2) && (arg2 >= D_8011D730[index]) &&
+            (arg0 != D_8011CDF8[index])) {
+            D_800BE4DC = D_8011CDF8[index];
+            D_800BE4D8 = 1;
+            return 0x40;
+        }
+    }
+
+    return 0;
+}
 
 void func_8001FEB0(void) {
     u32 index;
@@ -435,7 +509,40 @@ void GameState_Gameplay(void) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/func_80021098.s")
+void func_80021098(void) {
+    u16 prev_game_sub_state;
+
+    D_800BE4EC = 1;
+    gGameState = GAMESTATE_GAMEPLAY;
+    prev_game_sub_state = gGameStateSubState;
+    gGameStateSubState = 0;
+    D_800CA244--;
+    if (D_800CA244 == 0) {
+        D_800CA23C++;
+        D_800CA240 = gButtonHold = D_800CBDFC[D_800CA238][D_800CA23C];
+        D_800CA23C++;
+        D_800CA244 = D_800CBDFC[D_800CA238][D_800CA23C];
+    }
+    else {
+        gButtonHold = D_800CA240;
+    }
+
+    D_800CA250--;
+    if (D_800CA250 == 0) {
+        D_800CA248++;
+        D_800CA24C = gButtonPress = D_800CBE0C[D_800CA238][D_800CA248] | (gButtonPress & D_800BE500);
+        D_800CA248++;
+        D_800CA250 = D_800CBE0C[D_800CA238][D_800CA248];
+    }
+    else {
+        gButtonPress = D_800CA24C | (gButtonPress & D_800BE500);
+    }
+    GameState_Gameplay();
+    D_80104098[0x1440] = 0;
+    D_80104098[0x1490] = 0;
+    gGameState = GAMESTATE_ATTRACT;
+    gGameStateSubState = prev_game_sub_state;
+}
 
 #pragma GLOBAL_ASM("asm/nonmatchings/1F1E0/GameState_Attract.s")
 

--- a/src/27F70.c
+++ b/src/27F70.c
@@ -5,6 +5,10 @@ extern u16 D_800CA230;
 extern u32 D_80137458;
 extern u16 D_80178136;
 
+extern s8 D_800D2204[];
+extern s8 D_800D2228[];
+extern s8 D_800D222C[];
+
 extern void Actor_ClearRange_10To20(void);
 extern void Actor_ClearRange_30To90(void);
 extern void Actor_ClearRange_90ToC0(void);
@@ -162,22 +166,61 @@ void func_80028C00(s32 arg0) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/27F70/func_800291AC.s")
 
-#pragma GLOBAL_ASM("asm/nonmatchings/27F70/func_800294E0.s")
+s32 func_800294E0(s32 arg0, s32 arg1) {
+    s32 tmp;
+    s32 var_v1;
+    s32 var_a0;
+    s8* var_v0;
+    u8 ret;
 
-s32 func_800295D8(void) {
-    return (func_800294E0() + 0x100) & 0x200;
+    var_v0 = D_800D2228;
+    if (arg0 == 0) {
+        return (arg1 > 0) ? 0x100 : 0x300;
+    }
+    if (arg1 == 0) {
+        return (arg0 > 0) ? 0 : 0x200;
+    }
+    if (arg0 < 0) {
+        arg0 = -arg0;
+        var_v0 = D_800D222C;
+    }
+    if (arg1 < 0) {
+        arg1 = -arg1;
+        var_v0 += 2;
+    }
+    if (arg0 < arg1) {
+        tmp = arg0;
+        arg0 = arg1;
+        arg1 = tmp;
+        var_v0 += 1;
+    }
+    var_v1 = (arg0 * 4) / arg1;
+    if (var_v1 > 35) {
+        var_v1 = 35;
+    }
+    var_v1 = D_800D2204[var_v1];
+    var_a0 = *var_v0;
+    if (var_a0 < 0) {
+        var_v1 = -var_v1;
+    }
+    var_v1 += (var_a0 * 2);
+    return (var_v1 & 0xFF) * 4;
 }
 
-s32 func_80029600(void) {
-    return (func_800294E0() + 0x80) & 0x300;
+s32 func_800295D8(s32 arg0, s32 arg1) {
+    return (func_800294E0(arg0, arg1) + 0x100) & 0x200;
 }
 
-s32 func_80029628(void) {
-    return (func_800294E0() + 0x40) & 0x380;
+s32 func_80029600(s32 arg0, s32 arg1) {
+    return (func_800294E0(arg0, arg1) + 0x80) & 0x300;
 }
 
-s32 func_80029650(void) {
-    return (func_800294E0() + 0x20) & 0x3C0;
+s32 func_80029628(s32 arg0, s32 arg1) {
+    return (func_800294E0(arg0, arg1) + 0x40) & 0x380;
+}
+
+s32 func_80029650(s32 arg0, s32 arg1) {
+    return (func_800294E0(arg0, arg1) + 0x20) & 0x3C0;
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/27F70/func_80029678.s")

--- a/src/27F70.c
+++ b/src/27F70.c
@@ -22,7 +22,6 @@ extern void func_8003FD0C(s32, s16, s16, s16, s32);
 extern void func_80042864(u16);
 extern void func_800423A0(u16);
 extern void func_800427E0(u16);
-extern s32 func_800294E0(void);
 
 #pragma GLOBAL_ASM("asm/nonmatchings/27F70/func_80027370.s")
 

--- a/src/gamestate.c
+++ b/src/gamestate.c
@@ -10,14 +10,14 @@ u16 func_8000178C(void);
 
 void func_800012F0(void) {
     if (gGameState == GAMESTATE_GAMEPLAY) {
-        if ((gDebugBitfeild & 0x200) && (gGamePaused == 0)) {
+        if ((gDebugBitfield & 0x200) && (gGamePaused == 0)) {
             gGamePaused = 1;
         }
 
         if (gGamePaused != 0 && gGameStateSubState == 0x10) {
             if ((gButtonPress & D_800BE500) || (gButtonPress & D_800BE518)) {
                 // if this is true, you can pause while not drawing the pause screen (it still processes though?)
-                if (gDebugBitfeild & 0x100) {
+                if (gDebugBitfield & 0x100) {
                     func_80020844(); // PauseGame_RestoreVolume ?
                     func_800208D4(); // PauseGame_Unpause ?
                 }
@@ -30,8 +30,8 @@ void func_800012F0(void) {
             // player->health >= 0
             if (gActors[0].health >= 0) {
                 gGamePaused = 1;
-                gDebugBitfeild &= ~0x10;
-                if (gDebugBitfeild & 0x100) {
+                gDebugBitfield &= ~0x10;
+                if (gDebugBitfield & 0x100) {
                     gGameStateSubState = 0x10;
                 }
                 else {
@@ -91,19 +91,19 @@ void func_8000147C(void) {
     func_8000F290(); // DrawLifeBar
     func_80009BE0();
 
-    if (gDebugBitfeild & 1) {
+    if (gDebugBitfield & 0x1) {
         func_8002167C();
     }
 
-    if (gDebugBitfeild & 0x8000) {
+    if (gDebugBitfield & 0x8000) {
         func_8001FF28();
     }
 
-    if (gDebugBitfeild & 0x40) {
+    if (gDebugBitfield & 0x40) {
         func_80021658();
     }
 
-    if ((gDebugBitfeild & 0x1020) == 0x1000) {
+    if ((gDebugBitfield & 0x1020) == 0x1000) {
         func_80021660();
     }
 

--- a/versions/us1/mischiefmakers.yaml
+++ b/versions/us1/mischiefmakers.yaml
@@ -92,7 +92,7 @@ segments:
       - [0x0156F0, asm]
       - [0x017A70, c]
       - [0x01E7A0, c, actor_init]
-      - [0x01F1E0, asm]
+      - [0x01F1E0, c]
       - [0x022290, asm, letterbox]
       - [0x023070, asm, lifebar]
       - [0x023910, asm, soft_reset]

--- a/versions/us1/symbol_addrs_data.txt
+++ b/versions/us1/symbol_addrs_data.txt
@@ -91,7 +91,7 @@ D_800E8F7C = 0x800E8F7C;
 gRngSeed = 0x800BE5A4; // size:0x2
 D_800BE5F4 = 0x800BE5F4; // size:0x4
 
-gDebugBitfeild = 0x800BE6AC; // size:0x2
+gDebugBitfield = 0x800BE6AC; // size:0x2
 
 gCurrentFramebufferIndex = 0x800BE700; // size:0x2
 gCurrentDisplayListBase = 0x800EF4F4; // size:0x4

--- a/versions/us1/us1_report.json
+++ b/versions/us1/us1_report.json
@@ -1,13 +1,13 @@
 {
   "measures": {
-    "fuzzy_match_percent": 10.560878,
-    "total_code": "1994304",
-    "matched_code": "210616",
-    "matched_code_percent": 10.560878,
+    "fuzzy_match_percent": 10.917826,
+    "total_code": "1994280",
+    "matched_code": "217732",
+    "matched_code_percent": 10.917826,
     "matched_data_percent": 100.0,
-    "total_functions": 4699,
-    "matched_functions": 812,
-    "matched_functions_percent": 17.280272398382635,
+    "total_functions": 4700,
+    "matched_functions": 846,
+    "matched_functions_percent": 18.0,
     "complete_data_percent": 100.0,
     "total_units": 387
   },
@@ -2404,17 +2404,21 @@
     {
       "name": "1F1E0",
       "measures": {
+        "fuzzy_match_percent": 55.295254,
         "total_code": "12464",
+        "matched_code": "6892",
+        "matched_code_percent": 55.295254,
         "matched_data_percent": 100.0,
-        "total_functions": 35,
-        "total_units": 1,
-        "matched_functions": 0,
-        "matched_functions_percent": 0.0
+        "total_functions": 36,
+        "matched_functions": 33,
+        "matched_functions_percent": 91.66666666666666,
+        "total_units": 1
       },
       "sections": [
         {
           "name": ".text",
           "size": "12464",
+          "fuzzy_match_percent": 55.295254,
           "metadata": {
             "virtual_address": "2147608032"
           }
@@ -2424,6 +2428,7 @@
         {
           "name": "func_8001E5E0",
           "size": "276",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608032"
           }
@@ -2431,6 +2436,7 @@
         {
           "name": "func_8001E6F4",
           "size": "276",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608308"
           }
@@ -2438,6 +2444,7 @@
         {
           "name": "func_8001E808",
           "size": "12",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608584"
           }
@@ -2445,6 +2452,7 @@
         {
           "name": "func_8001E814",
           "size": "208",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608596"
           }
@@ -2452,6 +2460,7 @@
         {
           "name": "func_8001E8E4",
           "size": "128",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608804"
           }
@@ -2459,6 +2468,7 @@
         {
           "name": "func_8001E964",
           "size": "120",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147608932"
           }
@@ -2466,6 +2476,7 @@
         {
           "name": "func_8001E9DC",
           "size": "256",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147609052"
           }
@@ -2473,6 +2484,7 @@
         {
           "name": "func_8001EADC",
           "size": "176",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147609308"
           }
@@ -2480,6 +2492,7 @@
         {
           "name": "func_8001EB8C",
           "size": "144",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147609484"
           }
@@ -2494,6 +2507,7 @@
         {
           "name": "func_8001F88C",
           "size": "492",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147612812"
           }
@@ -2501,6 +2515,7 @@
         {
           "name": "func_8001FA78",
           "size": "552",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147613304"
           }
@@ -2508,6 +2523,7 @@
         {
           "name": "func_8001FCA0",
           "size": "528",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147613856"
           }
@@ -2515,6 +2531,7 @@
         {
           "name": "func_8001FEB0",
           "size": "120",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614384"
           }
@@ -2522,6 +2539,7 @@
         {
           "name": "func_8001FF28",
           "size": "8",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614504"
           }
@@ -2529,20 +2547,31 @@
         {
           "name": "func_8001FF30",
           "size": "32",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614512"
           }
         },
         {
           "name": "func_8001FF50",
-          "size": "88",
+          "size": "80",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614544"
           }
         },
         {
+          "name": "func_8001FFA0",
+          "size": "8",
+          "fuzzy_match_percent": 100.0,
+          "metadata": {
+            "virtual_address": "2147614624"
+          }
+        },
+        {
           "name": "func_8001FFA8",
           "size": "124",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614632"
           }
@@ -2550,6 +2579,7 @@
         {
           "name": "func_80020024",
           "size": "808",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147614756"
           }
@@ -2557,6 +2587,7 @@
         {
           "name": "func_8002034C",
           "size": "656",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147615564"
           }
@@ -2564,6 +2595,7 @@
         {
           "name": "func_800205DC",
           "size": "512",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147616220"
           }
@@ -2571,6 +2603,7 @@
         {
           "name": "func_800207DC",
           "size": "104",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147616732"
           }
@@ -2578,6 +2611,7 @@
         {
           "name": "func_80020844",
           "size": "144",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147616836"
           }
@@ -2585,6 +2619,7 @@
         {
           "name": "func_800208D4",
           "size": "88",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147616980"
           }
@@ -2592,6 +2627,7 @@
         {
           "name": "func_8002092C",
           "size": "296",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147617068"
           }
@@ -2599,6 +2635,7 @@
         {
           "name": "func_80020A54",
           "size": "60",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147617364"
           }
@@ -2613,6 +2650,7 @@
         {
           "name": "GameState_Gameplay",
           "size": "100",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147618868"
           }
@@ -2620,6 +2658,7 @@
         {
           "name": "func_80021098",
           "size": "472",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147618968"
           }
@@ -2634,6 +2673,7 @@
         {
           "name": "func_80021620",
           "size": "56",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147620384"
           }
@@ -2641,6 +2681,7 @@
         {
           "name": "func_80021658",
           "size": "8",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147620440"
           }
@@ -2648,6 +2689,7 @@
         {
           "name": "func_80021660",
           "size": "8",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147620448"
           }
@@ -2655,6 +2697,7 @@
         {
           "name": "func_80021668",
           "size": "20",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147620456"
           }
@@ -2662,6 +2705,7 @@
         {
           "name": "func_8002167C",
           "size": "20",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147620476"
           }
@@ -3678,21 +3722,21 @@
     {
       "name": "27F70",
       "measures": {
-        "fuzzy_match_percent": 2.0883477,
+        "fuzzy_match_percent": 2.3078012,
         "total_code": "113008",
-        "matched_code": "2360",
-        "matched_code_percent": 2.0883477,
+        "matched_code": "2608",
+        "matched_code_percent": 2.3078012,
         "matched_data_percent": 100.0,
         "total_functions": 360,
-        "matched_functions": 47,
-        "matched_functions_percent": 13.055555555555557,
+        "matched_functions": 48,
+        "matched_functions_percent": 13.333333333333334,
         "total_units": 1
       },
       "sections": [
         {
           "name": ".text",
           "size": "113008",
-          "fuzzy_match_percent": 2.0883477,
+          "fuzzy_match_percent": 2.3078012,
           "metadata": {
             "virtual_address": "2147644272"
           }
@@ -4071,6 +4115,7 @@
         {
           "name": "func_800294E0",
           "size": "248",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147652832"
           }
@@ -15343,8 +15388,8 @@
       "name": "ultralib/os/writebackdcacheall",
       "measures": {
         "fuzzy_match_percent": 100.0,
-        "total_code": "48",
-        "matched_code": "48",
+        "total_code": "40",
+        "matched_code": "40",
         "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 1,
@@ -15355,7 +15400,7 @@
       "sections": [
         {
           "name": ".text",
-          "size": "48",
+          "size": "40",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148118176"
@@ -15365,7 +15410,7 @@
       "functions": [
         {
           "name": "osWritebackDCacheAll",
-          "size": "48",
+          "size": "40",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148118176"
@@ -22051,8 +22096,8 @@
       "name": "ultralib/os/setcompare",
       "measures": {
         "fuzzy_match_percent": 100.0,
-        "total_code": "16",
-        "matched_code": "16",
+        "total_code": "12",
+        "matched_code": "12",
         "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 1,
@@ -22063,7 +22108,7 @@
       "sections": [
         {
           "name": ".text",
-          "size": "16",
+          "size": "12",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148226416"
@@ -22073,7 +22118,7 @@
       "functions": [
         {
           "name": "__osSetCompare",
-          "size": "16",
+          "size": "12",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148226416"
@@ -23201,8 +23246,8 @@
       "name": "ultralib/os/getcause",
       "measures": {
         "fuzzy_match_percent": 100.0,
-        "total_code": "16",
-        "matched_code": "16",
+        "total_code": "12",
+        "matched_code": "12",
         "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 1,
@@ -23213,7 +23258,7 @@
       "sections": [
         {
           "name": ".text",
-          "size": "16",
+          "size": "12",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148247120"
@@ -23223,7 +23268,7 @@
       "functions": [
         {
           "name": "__osGetCause",
-          "size": "16",
+          "size": "12",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148247120"
@@ -23242,8 +23287,8 @@
       "name": "ultralib/rmon/rmonrcp",
       "measures": {
         "fuzzy_match_percent": 100.0,
-        "total_code": "176",
-        "matched_code": "176",
+        "total_code": "168",
+        "matched_code": "168",
         "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 4,
@@ -23254,7 +23299,7 @@
       "sections": [
         {
           "name": ".text",
-          "size": "176",
+          "size": "168",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148247136"
@@ -23288,7 +23333,7 @@
         },
         {
           "name": "__rmonRunRCP",
-          "size": "48",
+          "size": "40",
           "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2148247264"
@@ -47288,14 +47333,14 @@
       "id": "total_matching",
       "name": "Total Matching",
       "measures": {
-        "fuzzy_match_percent": 10.560878,
-        "total_code": "1994304",
-        "matched_code": "210616",
-        "matched_code_percent": 10.560878,
+        "fuzzy_match_percent": 10.917826,
+        "total_code": "1994280",
+        "matched_code": "217732",
+        "matched_code_percent": 10.917826,
         "matched_data_percent": 100.0,
-        "total_functions": 4699,
-        "matched_functions": 812,
-        "matched_functions_percent": 17.280272398382635,
+        "total_functions": 4700,
+        "matched_functions": 846,
+        "matched_functions_percent": 18.0,
         "complete_data_percent": 100.0,
         "total_units": 387
       }
@@ -47304,12 +47349,12 @@
       "id": "main_code_segment",
       "name": "Main Code Segment",
       "measures": {
-        "total_code": "772208",
-        "matched_code": "181688",
-        "matched_code_percent": 23.52837577440275,
-        "total_functions": 2156,
-        "matched_functions": 707,
-        "matched_functions_percent": 32.7922077922078,
+        "total_code": "772184",
+        "matched_code": "188804",
+        "matched_code_percent": 24.45064906809776,
+        "total_functions": 2157,
+        "matched_functions": 741,
+        "matched_functions_percent": 34.35326842837274,
         "total_units": 265
       }
     },
@@ -47611,13 +47656,16 @@
       "id": "1F1E0",
       "name": "1F1E0",
       "measures": {
+        "fuzzy_match_percent": 55.295254,
         "total_code": "12464",
+        "matched_code": "6892",
+        "matched_code_percent": 55.295254,
         "matched_data_percent": 100.0,
-        "total_functions": 35,
+        "total_functions": 36,
+        "matched_functions": 33,
+        "matched_functions_percent": 91.66666666666666,
         "complete_data_percent": 100.0,
-        "total_units": 1,
-        "matched_functions": 0,
-        "matched_functions_percent": 0.0
+        "total_units": 1
       }
     },
     {
@@ -47692,14 +47740,14 @@
       "id": "27F70",
       "name": "27F70",
       "measures": {
-        "fuzzy_match_percent": 2.0883477,
+        "fuzzy_match_percent": 2.3078012,
         "total_code": "113008",
-        "matched_code": "2360",
-        "matched_code_percent": 2.0883477,
+        "matched_code": "2608",
+        "matched_code_percent": 2.3078012,
         "matched_data_percent": 100.0,
         "total_functions": 360,
-        "matched_functions": 47,
-        "matched_functions_percent": 13.055555555555557,
+        "matched_functions": 48,
+        "matched_functions_percent": 13.333333333333334,
         "complete_data_percent": 100.0,
         "total_units": 1
       }
@@ -48003,8 +48051,8 @@
       "name": "ultralib",
       "measures": {
         "fuzzy_match_percent": 100.0,
-        "total_code": "124864",
-        "matched_code": "124864",
+        "total_code": "124840",
+        "matched_code": "124840",
         "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 325,


### PR DESCRIPTION
- Decompile 1F1E0:
  - func_8001E808, func_80021668, func_8002167C, func_80021620,
  - GameState_Gameplay, func_80020A54, func_800208D4, func_80020844,
  - func_800207DC, func_800205DC, func_8002034C, func_80020024,
  - func_8001FFA8, func_8001FF50, func_8001FF30, func_8001FEB0,
  - func_8001F88C, func_8001EB8C, func_8001EADC, func_8001E9DC,
  - func_8001E964, func_8001E8E4, func_8001E814, func_8001E6F4,
  - func_8001E5E0, func_8002092C, func_80021098, func_8001FCA0, func_8001FA78
- Decompile 27F70:
  - func_800294E0 and fix up parameters to callers
- Rename: gDebugBitfeild -> gDebugBitfield