### PR TITLE
OK func_800423A0, various cleanup

### DIFF
--- a/include/actor.h
+++ b/include/actor.h
@@ -118,6 +118,8 @@ enum ActorFlags3 {
     ACTOR_FLAG3_UNK31 = (1U << 31U)
 };
 
+#define ACTOR_POSITION_HISTORY_COUNT 8
+
 typedef struct {
     /* 0x000 */ Mtx matrices[2]; // see A540: `actor + (gCurrentFramebufferIndex << 6)` before guTranslate/guScale/guRotate
     /* 0x080 */ u32 flags; // uses ActorFlags enum. 0 indicates inactive ("free") actor index
@@ -263,6 +265,7 @@ typedef struct {
                 /* 0x150 */ s32 var_150;
                 /* 0x150 */ s16 var_150_s16[2];
                 /* 0x150 */ s16* var_150_s16_ptr;
+                /* 0x150 */ FixedCoord unk_150; // TODO: array?
             };
             /* 0x154 */ s32 var_154;
             union {
@@ -292,47 +295,51 @@ typedef struct {
                 /* 0x16C */ ClanpotCheck clanpotCheck; // used by clanpots when mixing. returns true if requirements mat.
             };
             union {
-                /* 0x170 */ s32 unk_170;
-                /* 0x170 */ s16 unk_170_s16[2];
-                /* 0x170 */ u16 unk_170_u16[2];
-                /* 0x170 */ s8 unk_170_s8[4];
-            };
-            union {
-                /* 0x174 */ s32 unk_174;
-                /* 0x174 */ s16 unk_174_s16[2];
-                /* 0x174 */ u16 unk_174_u16[2];
-                /* 0x174 */ s32 unk_174_array[1]; // possibly redundant with unk_174
-            };
-            union {
-                /* 0x178 */ s32 unk_178; // assigned animation/frame table pointers(?) by matched overlays
-                /* 0x178 */ u16 unk_178_u16[2];
-            };
-            union {
-                /* 0x17C */ s32 unk_17C;
-                /* 0x17C */ s16 unk_17C_s16[2];
-                /* 0x17C */ s8 unk_17C_s8[4];
-                /* 0x17C */ ActorFunc pfn_17C; // used by "particle" actors
-                /* 0x17C */ Gfx* dlist_17C; // when ACTOR_GFLAG_3DOBJ is set in graphicFlags, field is treated as dlist pointer
-                /* 0x17C */ u8* texture_17C;
-            };
-            union {
-                /* 0x180 */ s32 unk_180;
-                /* 0x180 */ s16 unk_180_s16[2];
-                /* 0x180 */ u8 unk_180_u8[4];
-                /* 0x180 */ uintptr_t ptr_180; // can hold Vtx*, s16*, or u16* depending on actor type
-                /* 0x180 */ u16* palette_180;
-            };
-            union {
-                /* 0x184 */ s32 unk_184;
-                /* 0x184 */ s16 unk_184_s16[2];
-            };
-            union {
-                /* 0x188 */ s32 unk_188;
-                /* 0x188 */ s16 unk_188_s16;
-            };
-            union {
-                /* 0x18C */ s32 unk_18C; // field sometimes treated as int
-                /* 0x18C */ u16* palette_18C; // when ACTOR_GFLAG_PALETTE is set in graphicFlags, field is treated as palette pointer
+                /* 0x170 */ Position_U16 positionHistory[ACTOR_POSITION_HISTORY_COUNT]; // see: func_800423A0; TODO: find more uses
+                struct {
+                    union {
+                        /* 0x170 */ s32 unk_170;
+                        /* 0x170 */ s16 unk_170_s16[2];
+                        /* 0x170 */ u16 unk_170_u16[2];
+                        /* 0x170 */ s8 unk_170_s8[4];
+                    };
+                    union {
+                        /* 0x174 */ s32 unk_174;
+                        /* 0x174 */ s16 unk_174_s16[2];
+                        /* 0x174 */ u16 unk_174_u16[2];
+                    };
+                    union {
+                        /* 0x178 */ s32 unk_178; // assigned animation/frame table pointers(?) by matched overlays
+                        /* 0x178 */ u16 unk_178_u16[2];
+                    };
+                    union {
+                        /* 0x17C */ s32 unk_17C;
+                        /* 0x17C */ s16 unk_17C_s16[2];
+                        /* 0x17C */ s8 unk_17C_s8[4];
+                        /* 0x17C */ ActorFunc pfn_17C; // used by "particle" actors
+                        /* 0x17C */ Gfx* dlist_17C; // when ACTOR_GFLAG_3DOBJ is set in graphicFlags, field is treated as dlist pointer
+                        /* 0x17C */ u8* texture_17C;
+                    };
+                    union {
+                        /* 0x180 */ s32 unk_180;
+                        /* 0x180 */ s16 unk_180_s16[2];
+                        /* 0x180 */ u8 unk_180_u8[4];
+                        /* 0x180 */ uintptr_t ptr_180; // can hold Vtx*, s16*, or u16* depending on actor type
+                        /* 0x180 */ u16* palette_180;
+                    };
+                    union {
+                        /* 0x184 */ s32 unk_184;
+                        /* 0x184 */ s16 unk_184_s16[2];
+                    };
+                    union {
+                        /* 0x188 */ s32 unk_188;
+                        /* 0x188 */ s16 unk_188_s16;
+                    };
+                    union {
+                        /* 0x18C */ s32 unk_18C; // field sometimes treated as int
+                        /* 0x18C */ u16* palette_18C; // when ACTOR_GFLAG_PALETTE is set in graphicFlags, field is treated as palette pointer
+                    };
+                };
             };
             union {
                 /* 0x190 */ s32 unk_190;

--- a/include/actor.h
+++ b/include/actor.h
@@ -295,7 +295,7 @@ typedef struct {
                 /* 0x16C */ ClanpotCheck clanpotCheck; // used by clanpots when mixing. returns true if requirements mat.
             };
             union {
-                /* 0x170 */ Position_U16 positionHistory[ACTOR_POSITION_HISTORY_COUNT]; // see: func_800423A0; TODO: find more uses
+                /* 0x170 */ s32 positionHistory[ACTOR_POSITION_HISTORY_COUNT]; // see: func_800423A0; TODO: find more uses
                 struct {
                     union {
                         /* 0x170 */ s32 unk_170;

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -8,15 +8,19 @@
 // game uses Q16.16 fixed-point numbers for position and velocity values.
 typedef union {
     /* 0x00 */ s32 raw;
+    /* 0x00 */ s16 parts[2]; // 0 = whole, 1 = frac
     struct {
     /* 0x00 */ s16 whole;
     /* 0x02 */ s16 frac;
     };
 } FixedCoord;
 
-typedef struct {
-    /* 0x00 */ u16 positionX;
-    /* 0x02 */ u16 positionY;
+typedef union {
+    struct {
+        /* 0x00 */ u16 positionX;
+        /* 0x02 */ u16 positionY;
+    };
+    /* 0x00 */ s32 raw;
 } Position_U16; /* sizeof = 0x04 */
 
 typedef struct {

--- a/include/cosine.h
+++ b/include/cosine.h
@@ -6,7 +6,7 @@
 // Mischief Makers uses a 1024-step table of the cosine function for its sine/cosine math.
 extern f32 gCosineLookup[1024];
 
-//there is a second float table in the game that goes unused.
+// there is a second float table in the game that goes unused.
 extern f32 gUnusedFloatTable[512];
 
 #define COS_MASK (ARRAYLENGTH(gCosineLookup) - 1)
@@ -15,6 +15,7 @@ extern f32 gUnusedFloatTable[512];
 #define COS_DEG_90 (ARRAYLENGTH(gCosineLookup) / 4)
 #define COS_DEG_45 (ARRAYLENGTH(gCosineLookup) / 8)
 #define DEG_PER_INDEX (360.0 / (ARRAYLENGTH(gCosineLookup))) // = 0.3515625. used for sin/cos lookups
+#define COS_MASK_FIXED_UNIT (FIXED_UNIT(ARRAYLENGTH(gCosineLookup)) - 1)
 #define COS(x) gCosineLookup[(x) & COS_MASK]
 #define SIN(x) gCosineLookup[((x) - (s32)COS_DEG_90) & COS_MASK] //cos(x-pi/2)=sin(x)
 #define NEGSIN(x) gCosineLookup[((x) + COS_DEG_90) & COS_MASK] //cos(x+pi/2)=-sin(x)

--- a/src/11820.c
+++ b/src/11820.c
@@ -305,7 +305,7 @@ void func_80011B30(s16 arg0, s16 arg1, s8 arg2, s8 arg3, s8 arg4) {
     for (index = arg1; index < arg1 + arg3; index++) {
         for (jndex = arg0; jndex < arg0 + arg2; jndex++) {
             D_80108DE8[
-                (((((jndex << 5) + gScreenPosCurrentX.whole) - 0x80) >> 5) & D_800BE64C) + 
+                (((((jndex << 5) + gScreenPosCurrentX.whole) - 0x80) >> 5) & D_800BE64C) +
                 (((((D_800BE648 + (index << 5)) - gScreenPosCurrentY.whole) - 0x50) << D_800BE654) & D_800BE650)] = arg4;
             arg4 += 1;
         }
@@ -319,7 +319,7 @@ void func_80011C58(s16 arg0, s16 arg1, s8 arg2, s8 arg3) {
     for (index = arg1; index < arg1 + arg3; index++) {
         for (jndex = arg0; jndex < arg0 + arg2; jndex++) {
             D_80108DE8[
-                (((((jndex << 5) + gScreenPosCurrentX.whole) - 0x80) >> 5) & D_800BE64C) + 
+                (((((jndex << 5) + gScreenPosCurrentX.whole) - 0x80) >> 5) & D_800BE64C) +
                 (((((D_800BE648 + (index << 5)) - gScreenPosCurrentY.whole) - 0x50) << D_800BE654) & D_800BE650)] = 0;
         }
     }
@@ -364,7 +364,7 @@ void func_80011F44(s16 arg0, s16 arg1, s8 arg2, s8 arg3) {
 }
 
 void func_80012044(s16 arg0, s16 arg1, s16 arg2) {
-    D_8010CDF0[(((arg0 + gScreenPosCurrentX.whole) >> 4) & D_800BE658) + 
+    D_8010CDF0[(((arg0 + gScreenPosCurrentX.whole) >> 4) & D_800BE658) +
         ((((D_800BE648 - arg1) - gScreenPosCurrentY.whole) << D_800BE660) & D_800BE65C)] = arg2;
 }
 

--- a/src/156F0.c
+++ b/src/156F0.c
@@ -99,8 +99,7 @@ void ActorsUpdate_Position(void) {
 void func_80014F14(u16 actor_index, s32 arg1) {
     s32 temp_a3;
 
-    // fakematch: regalloc with `(0, `
-    temp_a3 = ((((gActors[actor_index].posX.whole) + (0, gScreenPosCurrentX.whole) + arg1) & ~0xF) - gScreenPosCurrentX.whole) - arg1;
+    temp_a3 = (((gScreenPosCurrentX.parts[0] + gActors[actor_index].posX.whole + arg1) & ~0xF) - gScreenPosCurrentX.parts[0]) - arg1;
     if (func_8005C6D0(temp_a3 - gActors[actor_index].posX.whole) < 0xF) {
         gActors[actor_index].posX.whole = temp_a3;
     }

--- a/src/241E0.c
+++ b/src/241E0.c
@@ -1155,7 +1155,7 @@ void func_80024E18(void) {
 void CameraUpdate_BeesTheOne(void) {
     switch (D_800BE634) {
     case 0:
-        gScreenPosTargetY.raw += 0x319A;
+        gScreenPosTargetY.raw += FIXED_UNIT(0.193756103515625);
         if (gScreenPosCurrentY.whole > 0x2E0) {
             gActors[0x91].flags = 0;
             gActors[0x90].flags = 0;
@@ -1163,7 +1163,7 @@ void CameraUpdate_BeesTheOne(void) {
         }
         break;
     case 1:
-        gScreenPosTargetY.raw += 0x319A;
+        gScreenPosTargetY.raw += FIXED_UNIT(0.193756103515625);
         if (gScreenPosCurrentY.whole > 0x3A8) {
             func_80024DD8();
             func_80024E18();
@@ -1172,7 +1172,7 @@ void CameraUpdate_BeesTheOne(void) {
         }
         break;
     case 2:
-        gScreenPosTargetY.raw += 0x319A;
+        gScreenPosTargetY.raw += FIXED_UNIT(0.193756103515625);
         D_800BE738 += FIXED_UNIT(2.0);
         if (gScreenPosCurrentY.whole > 0x4B0) {
             gDrawEnvLayer = FALSE;
@@ -1184,11 +1184,11 @@ void CameraUpdate_BeesTheOne(void) {
         break;
     }
     if (gScreenPosCurrentX.whole < 0x1900) {
-        D_800BE73C = 0x18CCD;
+        D_800BE73C = FIXED_UNIT(1.5500030517578125);
         gScreenPosTargetX.raw += D_800BE73C;
     }
     else {
-        D_800BE73C = (-gScreenPosCurrentX.whole * 0x27A) + 0x3F7640;
+        D_800BE73C = (-gScreenPosCurrentX.whole * FIXED_UNIT(0.009674072265625)) + FIXED_UNIT(63.4619140625);
         gScreenPosTargetX.raw += D_800BE73C;
     }
     func_8002488C();

--- a/src/28EF0.c
+++ b/src/28EF0.c
@@ -8601,7 +8601,7 @@ void ActorUpdate_WarpGate(u16 actor_index) {
         temp = (u16)gActors[actor_index].var_110 & 0xF;
         switch (temp) {
         case 2:
-            // fakematch: the zero term keeps IDO from reusing v1 for coord_index
+            // fakematch
             coord_index = gActors[actor_index].var_0D8 + (sp24 * 0);
             WarpGate_MoveUser(actor_index, &D_800D2860[coord_index]);
             break;

--- a/src/42E90.c
+++ b/src/42E90.c
@@ -138,19 +138,15 @@ void func_800423A0(u16 actor_index) {
         FROM_FIXED((SIN(angle) * FIXED_UNIT(40.0)) + position_y.raw) +
         gPlayerActor.posY.whole + gScreenPosCurrentY.parts[0];
 
-    position_x.raw = TO_FIXED(position_x.raw) + (u16)position_y.raw;
+    position_x.raw = (position_x.raw << 16) + (position_y.raw & 0xFFFF); // | doesn't work; can also be `TO_FIXED(position_x.raw) + (u16)position_y.raw;`
     for (history_index = 0; history_index < ACTOR_POSITION_HISTORY_COUNT; history_index++) {
-        position_y.raw = gActors[actor_index].positionHistory[(s32)history_index].raw;
-        gActors[actor_index].positionHistory[(s32)history_index].raw = position_x.raw;
+        position_y.raw = gActors[actor_index].positionHistory[(s32)history_index];
+        gActors[actor_index].positionHistory[(s32)history_index] = position_x.raw;
         position_x.raw = position_y.raw;
     }
 
-    gActors[actor_index].posX.whole =
-        FROM_FIXED(gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1].raw) -
-        gScreenPosCurrentX.whole;
-    gActors[actor_index].posY.whole =
-        gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1].raw -
-        (u16)gScreenPosCurrentY.whole;
+    gActors[actor_index].posX.whole = FROM_FIXED(gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1]) - gScreenPosCurrentX.whole;
+    gActors[actor_index].posY.whole = gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1] - (u16)gScreenPosCurrentY.whole;
 }
 
 void func_800427E0(u16 arg0) {

--- a/src/42E90.c
+++ b/src/42E90.c
@@ -62,50 +62,50 @@ void Actor11_State1(u16 actor_index) {
     gActors[actor_index].state++;
 }
 
-#ifdef NON_MATCHING
-// https://decomp.me/scratch/W3o78
 void func_800423A0(u16 actor_index) {
-    s32 y;
-    s32 x;
-    s32 var_a1_2;
+    FixedCoord position_x;
+    FixedCoord position_y;
+    s32 angle_delta;
     s32 angle;
-    u16 var_v1;
+    u16 history_index;
 
     if (gActors[actor_index].var_160 & 1) {
         gActors[actor_index].var_160 &= ~1;
+
         if (gButtonHold & gButton_DRight) {
             angle = FIXED_UNIT(0.5);
         }
         else if (gButtonHold & gButton_DLeft) {
-            angle = FIXED_UNIT(511.5);
+            angle = FIXED_UNIT(COS_DEG_180 - 0.5);
         }
         else if (gButtonHold & gButton_DUp) {
             if (gPlayerActor.flags & ACTOR_FLAG_FLIPPED) {
-                angle = FIXED_UNIT(256.5);
+                angle = FIXED_UNIT(COS_DEG_90 + 0.5);
             }
             else {
-                angle = FIXED_UNIT(255.5);
+                angle = FIXED_UNIT(COS_DEG_90 - 0.5);
             }
         }
         else if (gButtonHold & gButton_DDown) {
             if (gPlayerActor.flags & ACTOR_FLAG_FLIPPED) {
-                angle = FIXED_UNIT(767.5);
+                angle = FIXED_UNIT(COS_DEG_360 - COS_DEG_90 - 0.5);
             }
             else {
-                angle = FIXED_UNIT(768.5);
+                angle = FIXED_UNIT(COS_DEG_360 - COS_DEG_90 + 0.5);
             }
         }
         else {
             angle = gActors[actor_index].var_15C;
             gActors[actor_index].var_160 |= 1;
         }
+
         gActors[actor_index].var_15C = angle;
         angle = gActors[actor_index].var_158;
     }
     else {
-        x = (gActors[actor_index].var_15C - gActors[actor_index].var_158) & 0x03FFFFFF;
-        if (x != 0) {
-            if ((x < FIXED_UNIT(128.0)) || (x > FIXED_UNIT(896.0))) {
+        angle_delta = (gActors[actor_index].var_15C - gActors[actor_index].var_158) & COS_MASK_FIXED_UNIT;
+        if (angle_delta != 0) {
+            if (angle_delta < FIXED_UNIT(COS_DEG_45) || angle_delta > FIXED_UNIT(COS_DEG_360 - COS_DEG_45)) {
                 gActors[actor_index].unk_168 = Math_ApproachS32(gActors[actor_index].unk_168, FIXED_UNIT(3.0), FIXED_UNIT(2.0));
             }
             else {
@@ -115,34 +115,43 @@ void func_800423A0(u16 actor_index) {
         else if (gButtonHold & gButton_RTrig) {
             gActors[actor_index].var_160 |= 1;
         }
+
         angle = func_800298D0(gActors[actor_index].var_15C, gActors[actor_index].var_158, gActors[actor_index].unk_168);
     }
+
     gActors[actor_index].var_158 = angle;
     angle = FROM_FIXED(angle);
+
     if (gPlayerActor.flags & ACTOR_FLAG_FLIPPED) {
         gActors[actor_index].unk_16C += 24;
     }
     else {
         gActors[actor_index].unk_16C -= 24;
     }
-    x = COS(gActors[actor_index].unk_16C) * FIXED_UNIT(4.5);
-    y = SIN(gActors[actor_index].unk_16C) * FIXED_UNIT(4.5);
-    x = FROM_FIXED((COS(angle) * FIXED_UNIT(40.0)) + x) + gPlayerActor.posX.whole + gScreenPosCurrentX.whole;
-    y = FROM_FIXED((SIN(angle) * FIXED_UNIT(40.0)) + y) + gPlayerActor.posY.whole + gScreenPosCurrentY.whole;
-    
-    var_a1_2 = (x << 0x10) + (y & 0xFFFF);
-    for (var_v1 = 0; var_v1 < 8; var_v1++) {
-        angle = (&gActors[actor_index].unk_170)[var_v1];
-        (&gActors[actor_index].unk_170)[var_v1] = var_a1_2;
-        var_a1_2 = angle;
+
+    position_x.raw = COS(gActors[actor_index].unk_16C) * FIXED_UNIT(4.5);
+    position_y.raw = SIN(gActors[actor_index].unk_16C) * FIXED_UNIT(4.5);
+    position_x.raw =
+        FROM_FIXED((COS(angle) * FIXED_UNIT(40.0)) + position_x.raw) +
+        gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0];
+    position_y.raw =
+        FROM_FIXED((SIN(angle) * FIXED_UNIT(40.0)) + position_y.raw) +
+        gPlayerActor.posY.whole + gScreenPosCurrentY.parts[0];
+
+    position_x.raw = TO_FIXED(position_x.raw) + (u16)position_y.raw;
+    for (history_index = 0; history_index < ACTOR_POSITION_HISTORY_COUNT; history_index++) {
+        position_y.raw = gActors[actor_index].positionHistory[(s32)history_index].raw;
+        gActors[actor_index].positionHistory[(s32)history_index].raw = position_x.raw;
+        position_x.raw = position_y.raw;
     }
-    gActors[actor_index].posX.whole = FROM_FIXED(gActors[actor_index].unk_18C) - gScreenPosCurrentX.whole;
-    gActors[actor_index].posY.whole = gActors[actor_index].unk_18C - gScreenPosCurrentY.whole;
+
+    gActors[actor_index].posX.whole =
+        FROM_FIXED(gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1].raw) -
+        gScreenPosCurrentX.whole;
+    gActors[actor_index].posY.whole =
+        gActors[actor_index].positionHistory[ACTOR_POSITION_HISTORY_COUNT - 1].raw -
+        (u16)gScreenPosCurrentY.whole;
 }
-#else
-void func_800423A0(u16);
-#pragma GLOBAL_ASM("asm/nonmatchings/42E90/func_800423A0.s")
-#endif
 
 void func_800427E0(u16 arg0) {
     u16 index;

--- a/src/48A30.c
+++ b/src/48A30.c
@@ -192,8 +192,8 @@ void func_80048408(u16 actor_index) {
             break;
 
         case 1:
-            if (((s8*)&gActors[actor_index].unk_170)[0] == 0) {
-                if (((s8*)&gActors[actor_index].unk_170)[1] == 5) {
+            if (gActors[actor_index].unk_170_s8[0] == 0) {
+                if (gActors[actor_index].unk_170_s8[1] == 5) {
                     Sound_PlaySfx(SFX_MARINA_YAY);
                 }
             }

--- a/src/61B80.c
+++ b/src/61B80.c
@@ -480,12 +480,12 @@ void ActorUpdate_SpiralClouds(u16 actor_index) {
 }
 
 void func_80062300(u16 actor_index) {
-    gActors[actor_index].posX.raw = (((gActors[actor_index].posX.raw + gScreenPosCurrentX.raw) & 0xFFF00000) - gScreenPosCurrentX.raw) + FIXED_UNIT(8.0);
+    gActors[actor_index].posX.raw = (((gActors[actor_index].posX.raw + gScreenPosCurrentX.raw) & ~(FIXED_UNIT(16.0) - 1)) - gScreenPosCurrentX.raw) + FIXED_UNIT(8.0);
     gActors[actor_index].velocityX.raw = 0;
 }
 
 void func_80062360(u16 actor_index) {
-    gActors[actor_index].posY.raw = (((gActors[actor_index].posY.raw + gScreenPosCurrentY.raw) & 0xFFF00000) - gScreenPosCurrentY.raw) + FIXED_UNIT(8.0);
+    gActors[actor_index].posY.raw = (((gActors[actor_index].posY.raw + gScreenPosCurrentY.raw) & ~(FIXED_UNIT(16.0) - 1)) - gScreenPosCurrentY.raw) + FIXED_UNIT(8.0);
     gActors[actor_index].velocityY.raw = 0;
 }
 

--- a/src/66250.c
+++ b/src/66250.c
@@ -1237,7 +1237,7 @@ void func_80068FBC(u16 actor_index, u16 actor_state_1, u16 actor_state_2) {
     case 0x81:
     case 0x83:
         gActors[actor_index].state = actor_state_2;
-        break;;
+        break;
     case 0x82:
     case 0x84:
         gActors[actor_index].state = actor_state_1;
@@ -2107,7 +2107,6 @@ u16 func_8006BD08(u16 actor_index) {
         gActors[free_actor].posY.whole = gActors[actor_index].posY.whole;
         gActors[free_actor].posZ.whole = gActors[actor_index].posZ.whole - 1;
         gActors[actor_index].pfn_158(actor_index, free_actor);
-        if (1) {} // fakematch
         gActors[actor_index].unk_11C = free_actor;
         gActors[actor_index].unk_120 = gActors[free_actor].actorType;
         gActors[actor_index].var_158 = gActors[free_actor].velocityX.raw * gActors[actor_index].scaleX;

--- a/src/74A50.c
+++ b/src/74A50.c
@@ -1011,11 +1011,10 @@ void Clanblob_Update(u16 actor_index) {
         gActors[actor_index].unk_164 = 0;
         gActors[actor_index].unk_168 = 0;
         gActors[actor_index].unk_16C = 0;
-        // fakematches: (0, ). likely gScreenPosCurrent* were an array
-        gActors[actor_index].unk_170 = gActors[actor_index].posX.whole + (0, gScreenPosCurrentX.whole);
-        gActors[actor_index].unk_174 = gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole);
-        gActors[actor_index].unk_178 = gActors[actor_index].posX.whole + (0, gScreenPosCurrentX.whole);
-        gActors[actor_index].unk_17C = gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole);
+        gActors[actor_index].unk_170 = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
+        gActors[actor_index].unk_174 = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
+        gActors[actor_index].unk_178 = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
+        gActors[actor_index].unk_17C = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
         gActors[actor_index].unk_190 = 0;
         gActors[actor_index].unk_188 = 0;
         gActors[actor_index].palette_18C = D_800D18E4[(u16)gActors[actor_index].var_110 & 0xF];
@@ -1071,7 +1070,7 @@ void Clanblob_Update(u16 actor_index) {
                 Sound_PlaySfxAtActor2(SFX_0119, actor_index);
             }
         }
-        gActors[actor_index].unk_16C = func_800298D0(0, gActors[actor_index].unk_16C, 0x300000);
+        gActors[actor_index].unk_16C = func_800298D0(0, gActors[actor_index].unk_16C, FIXED_UNIT(48));
         func_800769AC(actor_index);
         break;
     case 0x12:
@@ -1088,12 +1087,12 @@ void Clanblob_Update(u16 actor_index) {
             gActors[actor_index].unk_13C_f32 = (gActors[actor_index].unk_134 - gActors[actor_index].scaleY) / 8;
         }
         if (gActors[actor_index].var_158 > 0) {
-            var_a0 = 0x03000000;
+            var_a0 = FIXED_UNIT(768);
         }
         else {
-            var_a0 = 0x01000000;
+            var_a0 = FIXED_UNIT(256);
         }
-        gActors[actor_index].unk_16C = func_800298D0(var_a0, gActors[actor_index].unk_16C, 0x300000);
+        gActors[actor_index].unk_16C = func_800298D0(var_a0, gActors[actor_index].unk_16C, FIXED_UNIT(48));
         func_800769AC(actor_index);
         break;
     case 0x20:
@@ -1133,10 +1132,10 @@ void Clanblob_Update(u16 actor_index) {
         switch (temp_v0) {
         case 0:
             if (gActiveFrames & 0x10) {
-                gActors[actor_index].unk_16C = func_800298D0(0x500000, gActors[actor_index].unk_16C, 0xE0000);
+                gActors[actor_index].unk_16C = func_800298D0(FIXED_UNIT(80), gActors[actor_index].unk_16C, FIXED_UNIT(14));
             }
             else {
-                gActors[actor_index].unk_16C = func_800298D0(0x03B00000, gActors[actor_index].unk_16C, 0xE0000);
+                gActors[actor_index].unk_16C = func_800298D0(FIXED_UNIT(944), gActors[actor_index].unk_16C, FIXED_UNIT(14));
             }
             if (gActiveFrames & 8) {
                 gActors[actor_index].unk_130 = 0.8f;
@@ -2390,7 +2389,7 @@ void func_8007B73C(u16 actor_index) {
         /* fallthrough */
     case 0x10:
         actor->var_154++;
-        func_80078FF0(actor_index, 0x18000, 0x2C00);
+        func_80078FF0(actor_index, FIXED_UNIT(1.5), FIXED_UNIT(0.171875));
         if (D_800E3584 & 0xC0000) {
             actor->flags ^= ACTOR_FLAG_FLIPPED;
         }
@@ -2488,7 +2487,7 @@ void func_8007B73C(u16 actor_index) {
                     actor->unk_0DA = 0x84;
                     actor->unk_0DB = 7;
                     actor->damage = actor->unk_114 * 20.0f;
-                    actor->unk_0F8.raw = actor->scaleX * 327680.0f;
+                    actor->unk_0F8.raw = actor->scaleX * FIXED_UNIT(5.0);
                     actor->unk_0FC.raw = FIXED_UNIT(4);
                 }
             }
@@ -2496,7 +2495,7 @@ void func_8007B73C(u16 actor_index) {
                 actor->flags &= (-ACTOR_FLAG_DRAW - D_800E3570);
                 ACTOR_GFX_INIT(actor_index, D_800D81C8);
                 if (actor->flags & ACTOR_FLAG_FLIPPED) {
-                    actor->var_158 = 0x2000000;
+                    actor->var_158 = FIXED_UNIT(512);
                 }
                 else {
                     actor->var_158 = 0;
@@ -2607,7 +2606,7 @@ void func_8007B73C(u16 actor_index) {
             actor->unk_114 = 30.0f;
             actor->unk_118 = -1.0f;
             Sound_PlaySfx(SFX_BOOM_0045);
-            actor->unk_168 = Math_Atan2(actor->velocityX.raw, actor->velocityY.raw) << 0x10;
+            actor->unk_168 = TO_FIXED(Math_Atan2(actor->velocityX.raw, actor->velocityY.raw));
         }
         break;
     case 0x40:

--- a/src/84BB0.c
+++ b/src/84BB0.c
@@ -675,8 +675,8 @@ void func_80085F78(u16 actor_index) {
 
     for (index = 0; index < ARRAYLENGTH(D_80182220); index++) { D_80182220[index] = 0; }
 
-    pos_x = ((gActors[actor_index].posX.whole + (0, gScreenPosCurrentX.whole)) & 0xFFF0) + 8; // fakematch
-    pos_y = ((gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole)) & 0xFFF0) + 8;
+    pos_x = ((gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0]) & 0xFFF0) + 8;
+    pos_y = ((gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0]) & 0xFFF0) + 8;
     gActors[actor_index].var_158 = 0;
     D_80182020[gActors[actor_index].unk_178] = (pos_x << 16) + pos_y;
     gActors[actor_index].unk_178++;
@@ -1310,17 +1310,17 @@ void func_80087B4C(u16 actor_index) {
     var_110_int = (s32) gActors[actor_index].var_110;
     gActors[actor_index].var_160 += (var_110_int & 0xF) * 8;
     gActors[actor_index].var_15C += (((var_110_int & 0xF0) >> 4) << 22);
-    gActors[actor_index].var_15C &= 0x03FFFFFF;
+    gActors[actor_index].var_15C &= COS_MASK_FIXED_UNIT;
 }
 
 void func_80087BDC(u16 actor_index) {
     s16 angle;
 
     gActors[actor_index].var_15C += gActors[actor_index].unk_164;
-    gActors[actor_index].var_15C &= 0x03FFFFFF;
-    angle = FROM_FIXED(gActors[actor_index].var_15C) & 0x3FF;
-    gActors[actor_index].posX.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_170) - (0, gScreenPosCurrentX.whole);
-    gActors[actor_index].posY.whole = ((SIN(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_174) - (0, gScreenPosCurrentY.whole);
+    gActors[actor_index].var_15C &= COS_MASK_FIXED_UNIT;
+    angle = FROM_FIXED(gActors[actor_index].var_15C) & COS_MASK;
+    gActors[actor_index].posX.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_170) - gScreenPosCurrentX.parts[0];
+    gActors[actor_index].posY.whole = ((SIN(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_174) - gScreenPosCurrentY.parts[0];
 }
 
 void ActorUpdate_Spikeball_OrbitXY(u16 actor_index) {
@@ -1497,7 +1497,7 @@ void func_80088720(u16 actor_index) {
     var_110_int = (s32) gActors[actor_index].var_110;
     gActors[actor_index].var_160 += (var_110_int & 0xF) * 8;
     gActors[actor_index].var_15C += (((var_110_int & 0xF0) >> 4) << 22);
-    gActors[actor_index].var_15C &= 0x03FFFFFF;
+    gActors[actor_index].var_15C &= COS_MASK_FIXED_UNIT;
 }
 
 void func_800887B0(u16 actor_index) {
@@ -1509,14 +1509,14 @@ void func_800887F0(u16 actor_index) {
 }
 
 void func_80088834(u16 actor_index) {
-    s16 angle = FROM_FIXED(gActors[actor_index].var_15C) & 0x3FF;
-    gActors[actor_index].posX.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_170) - (0, gScreenPosCurrentX.whole);
+    s16 angle = FROM_FIXED(gActors[actor_index].var_15C) & COS_MASK;
+    gActors[actor_index].posX.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_170) - gScreenPosCurrentX.parts[0];
     gActors[actor_index].unk_188 = (SIN(angle) * gActors[actor_index].var_160) * -3.0f;
 }
 
 void func_80088944(u16 actor_index) {
-    s16 angle = FROM_FIXED(gActors[actor_index].var_15C) & 0x3FF;
-    gActors[actor_index].posY.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_174) - (0, gScreenPosCurrentY.whole);
+    s16 angle = FROM_FIXED(gActors[actor_index].var_15C) & COS_MASK;
+    gActors[actor_index].posY.whole = ((COS(angle) * gActors[actor_index].var_160) + gActors[actor_index].unk_174) - gScreenPosCurrentY.parts[0];
     gActors[actor_index].unk_188 = (SIN(angle) * gActors[actor_index].var_160) * -2.0f;
 }
 
@@ -1545,7 +1545,7 @@ void func_80088B08(u16 actor_index) {
     s32 delta_z;
 
     gActors[actor_index].var_15C += gActors[actor_index].unk_164;
-    gActors[actor_index].var_15C &= 0x03FFFFFF;
+    gActors[actor_index].var_15C &= COS_MASK_FIXED_UNIT;
     if (gActors[actor_index].unk_168 != 0) {
         func_80088944(actor_index);
     }
@@ -2272,9 +2272,9 @@ void func_8008AE78(u16 actor_index) {
     s32 pos_y;
     s32 temp_t6;
 
-    gActors[actor_index].var_154 = (gActors[actor_index].var_150 & 0xF) << 16;
-    gActors[actor_index].var_158 = ((gActors[actor_index].var_0D8 & 0xF000) >> 12) << 15;
-    temp_t6 = ((gActors[actor_index].var_0D8 & 0xF00) >> 8) << 19;
+    gActors[actor_index].var_154 = TO_FIXED(gActors[actor_index].var_150 & 0xF);
+    gActors[actor_index].var_158 = ((gActors[actor_index].var_0D8 & 0xF000) >> 12) * FIXED_UNIT(0.5);
+    temp_t6 = ((gActors[actor_index].var_0D8 & 0xF00) >> 8) * FIXED_UNIT(8.0);
     pos_y = gActors[actor_index].posY.raw + gScreenPosCurrentY.raw;
     gActors[actor_index].var_15C = pos_y + temp_t6;
     gActors[actor_index].var_160 = pos_y - temp_t6;
@@ -2678,7 +2678,7 @@ void func_8008C304(u16 actor_index) {
         gActors[actor_index].unk_170 = (s32) gActors[actor_index].var_110;
         D_801822A0[gActors[actor_index].var_154][0] = 
             ((((gActors[actor_index].posX.whole + gScreenPosCurrentX.whole) & 0xFFF0) + 8) << 16) + 
-            (((gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole)) & 0xFFF0) + 8); // fakematch: (0, )
+            (((gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0]) & 0xFFF0) + 8);
         gActors[actor_index].unk_178 = 1;
         gActors[actor_index].state++;
         // fallthrough

--- a/src/8D0A0.c
+++ b/src/8D0A0.c
@@ -222,8 +222,8 @@ void func_8008CC00(void) {
     D_800BE5F4.unk_00_u32 = 5;
     gPlayerActor.posX.whole = gActors[index].posX.whole;
     gPlayerActor.posY.whole = gActors[index].posY.whole;
-    gPlayerPosX.whole = gActors[index].posX.whole + (0, gScreenPosCurrentX.whole); // fakematch
-    gPlayerPosY.whole = gActors[index].posY.whole + (0, gScreenPosCurrentY.whole); // fakematch
+    gPlayerPosX.whole = gActors[index].posX.whole + gScreenPosCurrentX.parts[0];
+    gPlayerPosY.whole = gActors[index].posY.whole + gScreenPosCurrentY.parts[0];
     gPlayerActor.flags &= ~0x20;
     gPlayerActor.flags |= (gActors[index].flags & 0x20);
     D_800D294C = 0;
@@ -605,8 +605,8 @@ void func_8008DF20(u16 actor_index) {
             gPlayerActor.flags |= (gActors[actor_index].flags & ACTOR_FLAG_FLIPPED);
             gPlayerActor.posX.raw = gActors[actor_index].posX.raw;
             gPlayerActor.posY.raw = gActors[actor_index].posY.raw;
-            gPlayerPosX.whole = gActors[actor_index].posX.whole + (0, gScreenPosCurrentX.whole); // fakematch
-            gPlayerPosY.whole = gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole);
+            gPlayerPosX.whole = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
+            gPlayerPosY.whole = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
         }
     }
     func_8008CC90(actor_index);

--- a/src/8F080.c
+++ b/src/8F080.c
@@ -2315,14 +2315,13 @@ void func_800907E4(u16 actor_index) {
         func_8008105C(actor_index, D_800E5E48, D_800E5CA4);
         break;
     }
-    if (gActors && gActors) {} // fakematch
     gActors[actor_index].unk_178 = (uintptr_t) D_800E8820;
     func_80081478(actor_index, D_800E5E48, 1);
     func_80081790(actor_index, D_800E89D4);
     func_800819A8(actor_index, D_800E5E48);
     gActors[actor_index].colorA = 0xFE;
-    gActors[actor_index + 0xA].unk_180 = gActors[actor_index].posX.whole + (0, gScreenPosCurrentX.whole);
-    gActors[actor_index + 0xB].unk_180 = gActors[actor_index].posY.whole + (0, gScreenPosCurrentY.whole);
+    gActors[actor_index + 0xA].unk_180 = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
+    gActors[actor_index + 0xB].unk_180 = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
     if (gActors[actor_index].graphicFlags & ACTOR_GFLAG_PALETTE) {
         index = ((gActors[actor_index].var_0D8 & 0x1F0) / 16) * 5;
         gActors[actor_index + 0x1].palette_18C = D_800E905C[index + 0];

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -154,11 +154,6 @@ void AnimateSpeechBubble(u16 actor_index, f32 arg1) {
     gActors[actor_index].scaleY = arg1 + (temp_f0 * SIN(gActiveFrames * 0x20));
 }
 
-typedef struct {
-    s16 unk0;
-    s16 unk2;
-} UnkActor_150; // TODO: could be FixedCoord if `s16 frac;`
-
 void func_8005E260(u16 actor_index) {
     s16 index;
     u16 actor_1;
@@ -208,10 +203,10 @@ void func_8005E260(u16 actor_index) {
         break;
     case 2:
         index = 0;
-        func_8005DFC8(((UnkActor_150*)(&gActors[actor_index].var_150))[index].unk2);
+        func_8005DFC8((&gActors[actor_index].unk_150)[index].frac);
         index++;
         while (index < 0x10) {
-            func_8005DF5C(((UnkActor_150*)(&gActors[actor_index].var_150))[index].unk2);
+            func_8005DF5C((&gActors[actor_index].unk_150)[index].frac);
             index++;
         }
         gActors[actor_index].state = 3;
@@ -293,10 +288,10 @@ void func_8005E56C(u16 actor_index) {
         break;
     case 2:
         index = 0;
-        func_8005DFC8(((UnkActor_150*)(&gActors[actor_index].var_150))[index].unk2);
+        func_8005DFC8((&gActors[actor_index].unk_150)[index].frac);
         index++;
         while (index < 0x10) {
-            func_8005DF5C(((UnkActor_150*)(&gActors[actor_index].var_150))[index].unk2);
+            func_8005DF5C((&gActors[actor_index].unk_150)[index].frac);
             index++;
         }
         D_800D5820 = actor_1;

--- a/src/overlay_0/overlay_67DBA0/67DC20.c
+++ b/src/overlay_0/overlay_67DBA0/67DC20.c
@@ -67,9 +67,9 @@ void func_80192108_67DC28(s32 arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/overlay_0/overlay_67DBA0/67DC20/func_8019219C_67DCBC.s")
 
 void func_8019237C_67DE9C(s32 arg0) {
-    gActors[0x4E].positionHistory[4].raw = 0x3C;
-    gActors[0x4F].positionHistory[4].raw = 8;
-    gActors[0x50].positionHistory[4].raw = 0xFE;
+    gActors[0x4E].positionHistory[4] = 0x3C;
+    gActors[0x4F].positionHistory[4] = 8;
+    gActors[0x50].positionHistory[4] = 0xFE;
     gActors[0x4E].unk_140_f32 = 0.0f;
 }
 

--- a/src/overlay_0/overlay_67DBA0/67DC20.c
+++ b/src/overlay_0/overlay_67DBA0/67DC20.c
@@ -67,11 +67,10 @@ void func_80192108_67DC28(s32 arg0) {
 #pragma GLOBAL_ASM("asm/nonmatchings/overlay_0/overlay_67DBA0/67DC20/func_8019219C_67DCBC.s")
 
 void func_8019237C_67DE9C(s32 arg0) {
-    // wtf? FAKEMATCH?
-    *(s32*)&gActors[0x4E].unk_180 = 0x3C;
-    *(s32*)&gActors[0x4F].unk_180 = 8;
-    *(s32*)&gActors[0x50].unk_180 = 0xFE;
-    *(f32*)&gActors[0x4E].unk_140_f32 = 0.0f;
+    gActors[0x4E].positionHistory[4].raw = 0x3C;
+    gActors[0x4F].positionHistory[4].raw = 8;
+    gActors[0x50].positionHistory[4].raw = 0xFE;
+    gActors[0x4E].unk_140_f32 = 0.0f;
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/overlay_0/overlay_67DBA0/67DC20/func_801923B0_67DED0.s")

--- a/src/overlay_0/overlay_6BCD80/6BCDD0.c
+++ b/src/overlay_0/overlay_6BCD80/6BCDD0.c
@@ -751,19 +751,17 @@ void func_80198E70_6C3B40(u16 arg0) {
 
 void func_8019902C_6C3CFC(u16 actor_index) {
     s16 diff;
-    s16* camera_x;
 
-    camera_x = &gScreenPosCurrentX.whole;
     if (!(gActors[actor_index].state & 0x800) && (D_801A6F3C_6D1C0C != 0xFFFF)) {
         diff = gActors[actor_index].posX.whole - gPlayerActor.posX.whole;
         if (diff >= 0x141) {
             gPlayerActor.posX.whole = gActors[actor_index].posX.whole - 0x140;
-            gPlayerPosX.whole = gPlayerActor.posX.whole + *camera_x;
+            gPlayerPosX.whole = gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0];
             return;
         }
         if (diff < -0x140) {
             gPlayerActor.posX.whole = gActors[actor_index].posX.whole + 0x140;
-            gPlayerPosX.whole = gPlayerActor.posX.whole + *camera_x;
+            gPlayerPosX.whole = gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0];
         }
     }
 }

--- a/src/overlay_0/overlay_6D2750/6D2780.c
+++ b/src/overlay_0/overlay_6D2750/6D2780.c
@@ -855,17 +855,16 @@ void func_80194334_6D49B4(u16 actor_index, s16 pos_y) {
     gActors[actor_index].actorType = ACTORTYPE_OVL0_INTRO_6;
     temp_actor_index = actor_index;
     Actor_Initialize(actor_index);
-    if (temp_actor_index) {} // FAKEMATCH
-    gActors[actor_index].graphicFlags = ACTOR_GFLAG_UNK11 | ACTOR_GFLAG_UNK8 | ACTOR_GFLAG_SCALE;
-    gActors[actor_index].flags = ACTOR_FLAG_ENABLED;
-    gActors[actor_index].graphicIndex = 0x2800;
-    gActors[actor_index].posX.whole = 0;
-    gActors[actor_index].posY.whole = pos_y;
-    gActors[actor_index].posZ.whole = -0xFF;
-    gActors[actor_index].unk_188 = 0;
-    gActors[actor_index].scaleX = 2.0f;
-    gActors[actor_index].scaleY = 2.0f;
-    gActors[actor_index].stateLower = gActors[0x31].stateLower;
+    gActors[temp_actor_index].graphicFlags = ACTOR_GFLAG_UNK11 | ACTOR_GFLAG_UNK8 | ACTOR_GFLAG_SCALE;
+    gActors[temp_actor_index].flags = ACTOR_FLAG_ENABLED;
+    gActors[temp_actor_index].graphicIndex = 0x2800;
+    gActors[temp_actor_index].posX.whole = 0;
+    gActors[temp_actor_index].posY.whole = pos_y;
+    gActors[temp_actor_index].posZ.whole = -0xFF;
+    gActors[temp_actor_index].unk_188 = 0;
+    gActors[temp_actor_index].scaleX = 2.0f;
+    gActors[temp_actor_index].scaleY = 2.0f;
+    gActors[temp_actor_index].stateLower = gActors[0x31].stateLower;
 }
 
 void func_801943E4_6D4A64(u16 arg0) {

--- a/src/overlay_1/overlay_749C90/749CB0.c
+++ b/src/overlay_1/overlay_749C90/749CB0.c
@@ -79,7 +79,7 @@ void func_8019BD48_74A8F8(s32 arg0) {
 
 void func_801A047C_74F02C(u16 actor_index) {
     func_801A202C_750BDC(actor_index);
-    D_801A4838_7533E8[((s16*)&gActors[actor_index + 2].unk_180)[0]](actor_index);
+    D_801A4838_7533E8[gActors[actor_index + 2].unk_180_s16[0]](actor_index);
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/overlay_1/overlay_749C90/749CB0/func_801A04F0_74F0A0.s")

--- a/src/overlay_3/overlay_7969B0/7969D0.c
+++ b/src/overlay_3/overlay_7969B0/7969D0.c
@@ -707,9 +707,9 @@ void func_801B21C8_798298(u16 actor_index) {
             gActors[actor_index].hitboxBX1 = 0x10;
             gActors[actor_index].graphicList = D_800E24EC;
             gActors[actor_index].graphicTimer = 1;
-            gActors[actor_index].posZ.whole = -8;\
+            gActors[actor_index].posZ.whole = -8;
             gActors[actor_index].var_158 = gScreenPosCurrentX.whole;
-            gActors[actor_index].var_158 += gActors[actor_index].posX.whole;\
+            gActors[actor_index].var_158 += gActors[actor_index].posX.whole;
             gActors[actor_index].var_15C = gScreenPosCurrentY.whole;
             gActors[actor_index].var_15C += gActors[actor_index].posY.whole;
             gActors[actor_index].state++;

--- a/src/overlay_3/overlay_7986D0/798740.c
+++ b/src/overlay_3/overlay_7986D0/798740.c
@@ -1273,8 +1273,8 @@ void func_801B0900_798740(u16 actor_index, f32 delta) {
     gActors[actor_index].unk_118 = gActors[actor_index].unk_120;
     gActors[actor_index].unk_11C = gActors[actor_index].unk_124;
     gActors[actor_index].unk_120 = gActors[actor_index].unk_12C;
-    gActors[actor_index].unk_124 = gScreenPosCurrentX.whole - (0 - gActors[actor_index].posX.whole);
-    gActors[actor_index].unk_12C = gScreenPosCurrentY.whole - (0 - gActors[actor_index].posY.whole);
+    gActors[actor_index].unk_124 = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
+    gActors[actor_index].unk_12C = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
     gActors[actor_index].unk_134 = gActors[actor_index].rotateZ - gActors[actor_index].unk_138;
     gActors[actor_index].unk_138 = gActors[actor_index].rotateZ;
 }
@@ -1919,7 +1919,7 @@ void func_801B2638_79A478(u16 actor_index) {
                     break;
 
                 case 1:
-                    if (gScreenPosCurrentY.whole - (0 - gActors[actor_index].posY.whole) >= 384) {
+                    if (gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0] >= 384) {
                         gActors[actor_index].unk_174_u16[1] = 0;
                     }
                     else {
@@ -2901,7 +2901,7 @@ void func_801B480C_79C64C(u16 actor_index) {
             }
 
             for (index = 0x40; index < 0x60; index += 2) {
-                if ((gActors[index].flags != 0) && (gActors[index].posY.whole + (0, gScreenPosCurrentY.whole)) < 328) {
+                if ((gActors[index].flags != 0) && (gActors[index].posY.whole + gScreenPosCurrentY.parts[0]) < 328) {
                     gActors[index + 0].flags = 0;
                     gActors[index + 1].flags = 0;
                     index2 = func_8003FF68(index, 1.0f);

--- a/src/overlay_3/overlay_7A13D0/7A1410.c
+++ b/src/overlay_3/overlay_7A13D0/7A1410.c
@@ -1503,11 +1503,6 @@ void func_801B36C0_7A41D0(u16 actor_index, s32 offset_x, s32 offset_y, s32 veloc
     if (new_actor_index == 0) {
         return;
     }
-    new_actor_index += 0;
-
-    if (1) {
-    }
-
     gActors[new_actor_index].graphicFlags = ACTOR_GFLAG_SCALE | ACTOR_GFLAG_ROTZ | ACTOR_GFLAG_UNK4;
     gActors[new_actor_index].flags = ACTOR_FLAG_ENABLED;
     gActors[new_actor_index].graphicList = D_801B5F8C_7A6A9C;
@@ -1537,11 +1532,6 @@ void func_801B3804_7A4314(u16 actor_index, s32 offset_x, s32 offset_y, s32 veloc
     if (new_actor_index == 0) {
         return;
     }
-    new_actor_index += 0;
-
-    if (1) {
-    }
-
     gActors[new_actor_index].graphicFlags = ACTOR_GFLAG_SCALE | ACTOR_GFLAG_ROTZ | ACTOR_GFLAG_UNK4;
     gActors[new_actor_index].flags = ACTOR_FLAG_ENABLED;
     gActors[new_actor_index].graphicList = D_801B5F8C_7A6A9C;
@@ -2401,7 +2391,7 @@ void func_801B57C8_7A62D8(u16 actor_index) {
 
                         gActors[actor_index].unk_174 = 0;
                         if ((gActors[actor_index].unk_16C > 0) && (gActors[actor_index].unk_16C < 4)) {
-                            if ((gActors[actor_index].unk_16C == 3) && ((gPlayerActor.posX.whole + (0, gScreenPosCurrentX.whole)) >= 2705)) {
+                            if ((gActors[actor_index].unk_16C == 3) && ((gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0]) >= 2705)) {
                                 SpawnTextBubble2(0x47, D_801B614C_7A6C5C, 0x40, 0x28, 0x19);
                                 gActors[actor_index].unk_16C = 0;
                                 gActors[actor_index].unk_170 &= 0xFFFF;
@@ -2435,7 +2425,7 @@ void func_801B57C8_7A62D8(u16 actor_index) {
     }
 
     if (gActors[actor_index].unk_16C == 3) {
-        if ((gPlayerActor.posX.whole + (0, gScreenPosCurrentX.whole)) >= 3368) {
+        if ((gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0]) >= 3368) {
             if (!(gActors[actor_index].unk_170 & 0x30000)) {
                 if (gActors[actor_index].unk_170 & 0xFFFF) {
                     if (gActors[actor_index].posX.whole < gPlayerActor.posX.whole) {

--- a/src/overlay_3/overlay_7A6E60/7A6E80.c
+++ b/src/overlay_3/overlay_7A6E60/7A6E80.c
@@ -465,7 +465,7 @@ void func_801B0A58_7A6FD8(u16 actor_index, s16 position_z) {
     }
 
     if (records[0].unk_00 == (gScreenPosCurrentX.raw * 0)) {
-        if ((((gScreenPosCurrentX.frac * 0) + ((s32)((s8*)&gScreenPosCurrentX)[0] * 0)) + ((s32)((s8*)&gScreenPosCurrentX)[1] * 0))) {
+        if ((((gScreenPosCurrentX.frac * 0) + ((s32)((s8*)&gScreenPosCurrentX)[0] * 0)) + (gScreenPosCurrentX.parts[1] * 0))) {
         }
         return;
     }
@@ -924,7 +924,7 @@ s16 func_801B1E80_7A8400(u16 actor_index) {
     count = gFestivalCompetitorCount;
     for (outer_remaining = (flags = 0); outer_remaining < count; outer_remaining = (outer_remaining + 1) & 0xFFFF) {
         first_actor = gFestivalCompetitors[outer_remaining].actorIndex;
-        if (((s16)gScreenPosCurrentX.whole + gActors[first_actor].posX.whole) >= gActors[actor_index].unk_174) {
+        if ((gScreenPosCurrentX.whole + gActors[first_actor].posX.whole) >= gActors[actor_index].unk_174) {
             if (gFestivalCompetitors[outer_remaining].rank == 0) {
                 s32 rank_value;
 
@@ -941,8 +941,6 @@ s16 func_801B1E80_7A8400(u16 actor_index) {
             }
         }
 
-        if (!(&gScreenPosCurrentX)) {
-        }
     }
 
     remaining = count - 1 + (outer_remaining * 0);
@@ -960,14 +958,15 @@ s16 func_801B1E80_7A8400(u16 actor_index) {
             entry_a += first_actor;
             loaded_a = *entry_a;
             entry_a += loaded_a * 0;
-            if (gActors[loaded_a].posX.whole && gActors[loaded_a].posX.whole) {
+            if (gActors[loaded_a].posX.whole) {
             }
 
             old_value = gActors[loaded_a].posX.whole;
-            if (old_value && old_value) {
+            if (old_value) {
             }
 
-            if ((s32)old_value < (position_b = gActors[sort_indices[first_actor + 1]].posX.whole)) {
+            position_b = gActors[sort_indices[first_actor + 1]].posX.whole;
+            if (old_value < position_b) {
                 loaded_a += 0;
                 *entry_a = sort_indices[first_actor + 1];
                 sort_indices[first_actor + 1] = (u64)loaded_a;
@@ -1784,7 +1783,7 @@ void func_801B3E9C_7AA41C(u16 actor_index) {
             func_801B3BCC_7AA14C(actor_index);
             if ((gFestivalCompetitors[gActors[actor_index].unk_16C_u32].unk_08 + 0x30) < gActors[actor_index].unk_17C) {
                 gActors[actor_index].unk_184_s16[1] = gActors[actor_index].unk_180;
-                gActors[actor_index].unk_184_s16[gActors[actor_index].unk_16C * 0] = gActors[actor_index].unk_17C;
+                gActors[actor_index].unk_184_s16[0] = gActors[actor_index].unk_17C;
                 gActors[actor_index].unk_174_u16[0]++;
                 gActors[actor_index].state = 0x60;
             }

--- a/src/overlay_3/overlay_7AC7F0/7AC820.c
+++ b/src/overlay_3/overlay_7AC7F0/7AC820.c
@@ -449,7 +449,7 @@ void func_801B0C38_7ACB58(u16 actor_index) {
         gActors[actor_index].graphicFlags = ACTOR_GFLAG_PALETTE;
         gActors[actor_index].flags = ACTOR_FLAG_ENABLED;
         gActors[actor_index].graphicIndex = (gActors[actor_index].var_0D8 * 2) + 0x2D4;
-        position_y = gActors[actor_index].posY.whole + (&gScreenPosCurrentY)[0].whole;
+        position_y = gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0];
         gActors[actor_index].var_158 = position_y;
         gActors[actor_index].var_15C = position_y;
         // fallthrough
@@ -657,7 +657,7 @@ s32 func_801B15C8_7AD4E8(u16 actor_index) {
     u16 position_x;
 
     actor_index = 0;
-    position_x = gActors[actor_index].posX.whole + (&gScreenPosCurrentX)[0].whole;
+    position_x = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
     result = 0;
     if (position_x < 0x220) {
         return 0;
@@ -1375,7 +1375,7 @@ void func_801B2CAC_7AEBCC(u16 actor_index) {
 
     case 0xA1:
         gActors[actor_index].unk_118 = 2.0f;
-        if ((gScreenPosCurrentX.whole + gActors[actor_index].posX.whole + (gActors[actor_index].unk_17C * 0)) >= 0x219) {
+        if ((gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0]) >= 0x219) {
             gActors[actor_index].unk_120 = (Rand() << 8) + (D_801B747C_7B339C + (D_80178292 & 0xFF))->unk_00 - 0x8000;
             gActors[actor_index].unk_11C = (D_801B747C_7B339C + (D_80178292 & 0xFF))->unk_04;
             gActors[actor_index].state = 0x130;

--- a/src/overlay_3/overlay_7B3FC0/7B3FE0.c
+++ b/src/overlay_3/overlay_7B3FC0/7B3FE0.c
@@ -144,7 +144,7 @@ void func_801B0900_7B3FE0(u16 actor_index) {
 
             ACTOR_INIT(new_actor_index, ACTORTYPE_OVL2_FEST_3);
 
-            *(&gActors[new_actor_index].posY.whole + ((position_x = index * position_multiplier) * 0)) = 0x54; // FAKEMATCH
+            gActors[new_actor_index].posY.parts[(position_x = index * position_multiplier) * 0] = 0x54; // fakematch
 
             position_x_copy = position_x;
             position_x = position_x_copy - 0x6E;

--- a/src/overlay_3/overlay_7B8760/7B87B0.c
+++ b/src/overlay_3/overlay_7B8760/7B87B0.c
@@ -748,7 +748,7 @@ void func_801B1E14_7B9CC4(u16 actor_index) {
 }
 
 void func_801B1FC0_7B9E70(u16 actor_index) {
-    gActors[actor_index].var_158 = gScreenPosCurrentX.whole - ((actor_index * 0) - gActors[actor_index].posX.whole);
+    gActors[actor_index].var_158 = gActors[actor_index].posX.whole + gScreenPosCurrentX.parts[0];
 
     switch (gActors[actor_index].state) {
         case 0:
@@ -1069,7 +1069,7 @@ void func_801B2C60_7BAB10(u16 actor_index) {
             break;
 
         case 1:
-            if ((gScreenPosCurrentY.whole < D_801B4550_7BC400[gActors[actor_index].var_0D8]) && (D_801B4558_7BC408[gActors[actor_index].var_0D8] < (gScreenPosCurrentY.whole - ((gActors[actor_index].velocityY.raw * 0) - gActors[actor_index].posY.whole)))) {
+            if ((gScreenPosCurrentY.whole < D_801B4550_7BC400[gActors[actor_index].var_0D8]) && (D_801B4558_7BC408[gActors[actor_index].var_0D8] < (gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0]))) {
                 gActors[actor_index].velocityY.raw = FIXED_UNIT(-1.0);
             }
             else if ((D_801B4550_7BC400[gActors[actor_index].var_0D8] < gScreenPosCurrentY.whole) && ((gActors[actor_index].posY.whole + gScreenPosCurrentY.whole) < D_801B4548_7BC3F8[gActors[actor_index].var_0D8])) {
@@ -1090,7 +1090,7 @@ void func_801B2C60_7BAB10(u16 actor_index) {
             break;
 
         case 2:
-            if ((D_801B4548_7BC3F8[gActors[actor_index].var_0D8] - 4) < (gScreenPosCurrentY.whole - ((gActors[actor_index].velocityY.raw * 0) - gActors[actor_index].posY.whole))) {
+            if ((D_801B4548_7BC3F8[gActors[actor_index].var_0D8] - 4) < (gActors[actor_index].posY.whole + gScreenPosCurrentY.parts[0])) {
                 gActors[actor_index].velocityY.raw = 0;
                 gActors[actor_index].state = 4;
             }
@@ -1254,14 +1254,14 @@ void func_801B349C_7BB34C(u16 actor_index) {
 
         case 0x200:
             gActors[actor_index].flags &= ~ACTOR_FLAG_DRAW;
-            gActors[actor_index].var_160 = gActors[actor_index - 1].posX.whole + (0, gScreenPosCurrentX.whole);
-            gActors[actor_index].unk_164 = gActors[actor_index - 1].posY.whole + (0, gScreenPosCurrentY.whole);
+            gActors[actor_index].var_160 = gActors[actor_index - 1].posX.whole + gScreenPosCurrentX.parts[0];
+            gActors[actor_index].unk_164 = gActors[actor_index - 1].posY.whole + gScreenPosCurrentY.parts[0];
             gActors[actor_index].state++;
             // fallthrough
 
         case 0x201:
-            position_x = gActors[actor_index - 1].posX.whole + (0, gScreenPosCurrentX.whole);
-            position_y = gActors[actor_index - 1].posY.whole + (0, gScreenPosCurrentY.whole);
+            position_x = gActors[actor_index - 1].posX.whole + gScreenPosCurrentX.parts[0];
+            position_y = gActors[actor_index - 1].posY.whole + gScreenPosCurrentY.parts[0];
             if ((position_x < (gActors[actor_index].var_160 - 0x10)) ||
                 ((gActors[actor_index].var_160 + 0x10) < position_x) ||
                 (position_y < (gActors[actor_index].unk_164 - 0x10)) ||
@@ -1280,10 +1280,10 @@ void func_801B349C_7BB34C(u16 actor_index) {
         case 0x301:
             if (gActors[actor_index - 1].state != 0x232) {
                 if (gActors[actor_index - 1].flags & ACTOR_FLAG_FLIPPED) {
-                    gActors[actor_index].unk_170 = gActors[actor_index - 1].posX.whole + (0, gScreenPosCurrentX.whole) + 0x10;
+                    gActors[actor_index].unk_170 = gActors[actor_index - 1].posX.whole + gScreenPosCurrentX.parts[0] + 0x10;
                 }
                 else {
-                    gActors[actor_index].unk_170 = gActors[actor_index - 1].posX.whole + (0, gScreenPosCurrentX.whole) - 0x10;
+                    gActors[actor_index].unk_170 = gActors[actor_index - 1].posX.whole + gScreenPosCurrentX.parts[0] - 0x10;
                 }
 
                 if ((gActors[actor_index].posX.whole + gScreenPosCurrentX.whole + 0x10) < gActors[actor_index].unk_170) {
@@ -1292,7 +1292,7 @@ void func_801B349C_7BB34C(u16 actor_index) {
                 else if (gActors[actor_index].unk_170 < (gActors[actor_index].posX.whole + gScreenPosCurrentX.whole - 0x10)) {
                     gActors[actor_index].flags |= ACTOR_FLAG_FLIPPED;
                 }
-                gActors[actor_index].unk_174 = gActors[actor_index - 1].posY.whole + (0, gScreenPosCurrentY.whole) + 0x30;
+                gActors[actor_index].unk_174 = gActors[actor_index - 1].posY.whole + gScreenPosCurrentY.parts[0] + 0x30;
             }
             func_801B338C_7BB23C(actor_index);
             break;
@@ -1481,8 +1481,8 @@ void func_801B3F8C_7BBE3C(u16 actor_index) {
         case 0:
             gActors[actor_slot].state = 0x110;
             gActors[actor_slot].unk_168 = 0x1F40;
-            gActors[actor_slot + 10].unk_180 = gActors[actor_slot].posX.whole + (0, gScreenPosCurrentX.whole);
-            gActors[actor_slot + 11].unk_180 = gActors[actor_slot].posY.whole + (0, gScreenPosCurrentY.whole);
+            gActors[actor_slot + 10].unk_180 = gActors[actor_slot].posX.whole + gScreenPosCurrentX.parts[0];
+            gActors[actor_slot + 11].unk_180 = gActors[actor_slot].posY.whole + gScreenPosCurrentY.parts[0];
             break;
 
         case 0x111:

--- a/src/overlay_3/overlay_7BC840/7BC850.c
+++ b/src/overlay_3/overlay_7BC840/7BC850.c
@@ -1501,7 +1501,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             gActors[actor_index].posX.whole = 0;
             gActors[actor_index].posY.whole = 8;
             gActors[actor_index].posZ.whole = -191;
-            gActors[0x50].unk_174_array[0] = 3;
+            gActors[0x50].positionHistory[1].raw = 3;
             func_8005DF40(0, 0x3C);
             gLookatEyeZ = 352.0f;
             Sound_PlaySfx(SFX_CROUD_CHATTER);
@@ -1513,19 +1513,19 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
                 func_8005DF5C(9);
                 D_800D5830 = 48;
                 D_800D5834 = -2;
-                gActors[0x50].unk_174_array[0] = 1;
+                gActors[0x50].positionHistory[1].raw = 1;
             }
             break;
 
         case 2:
             if (D_800D5824 == 0x4000) {
-                gActors[0x50].unk_174_array[0] = 6;
+                gActors[0x50].positionHistory[1].raw = 6;
             }
 
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x12C;
-                gActors[0x50].unk_174_array[0] = 0;
+                gActors[0x50].positionHistory[1].raw = 0;
                 Sound_PlaySfx(SFX_CROUD_CHEER);
                 Sound_StopSfx(SFX_CROUD_CHATTER);
                 func_801B3F84_7BFED4(1);
@@ -1536,7 +1536,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             D_801B4B64_7C0AB4--;
             if (D_801B4B64_7C0AB4 < 0) {
                 gActors[actor_index].state = gActors[actor_index].state + 1;
-                gActors[0x50].unk_174_array[0] = 1;
+                gActors[0x50].positionHistory[1].raw = 1;
                 func_8005DF5C(0xA);
                 D_800D5830 = 48;
                 D_800D5834 = -2;
@@ -1546,7 +1546,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
 
         case 4:
             if (D_800D5824 == 0x4000) {
-                gActors[0x50].unk_174_array[0] = 6;
+                gActors[0x50].positionHistory[1].raw = 6;
             }
 
             if (D_800D582C >= 2) {
@@ -1563,7 +1563,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (D_801B4B64_7C0AB4 < 0) {
                 if (func_8005DEFC() == 0) {
                     gActors[actor_index].state++;
-                    gActors[0x52].unk_174_array[0] = 5;
+                    gActors[0x52].positionHistory[1].raw = 5;
                 }
             }
             break;
@@ -1582,7 +1582,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].unk_174_array[0] = 6;
+                gActors[0x52].positionHistory[1].raw = 6;
             }
             break;
 
@@ -1600,7 +1600,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].unk_174_array[0] = 0;
+                gActors[0x52].positionHistory[1].raw = 0;
             }
             break;
 
@@ -1625,7 +1625,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             D_801B4B64_7C0AB4--;
             if (D_801B4B64_7C0AB4 < 0) {
                 gActors[actor_index].state = gActors[actor_index].state + 1;
-                gActors[0x52].unk_174_array[0] = 1;
+                gActors[0x52].positionHistory[1].raw = 1;
                 func_8005DF5C(0xE);
                 D_800D5830 = 96;
                 D_800D5834 = -2;
@@ -1636,7 +1636,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].unk_174_array[0] = 0;
+                gActors[0x52].positionHistory[1].raw = 0;
             }
             break;
 
@@ -1664,14 +1664,14 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
                 func_8005DF5C(0x10);
                 D_800D5830 = 96;
                 D_800D5834 = -2;
-                gActors[0x52].unk_174_array[0] = 1;
+                gActors[0x52].positionHistory[1].raw = 1;
             }
             break;
 
         case 17:
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
-                gActors[0x52].unk_174_array[0] = 6;
+                gActors[0x52].positionHistory[1].raw = 6;
             }
             break;
 

--- a/src/overlay_3/overlay_7BC840/7BC850.c
+++ b/src/overlay_3/overlay_7BC840/7BC850.c
@@ -1501,7 +1501,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             gActors[actor_index].posX.whole = 0;
             gActors[actor_index].posY.whole = 8;
             gActors[actor_index].posZ.whole = -191;
-            gActors[0x50].positionHistory[1].raw = 3;
+            gActors[0x50].positionHistory[1] = 3;
             func_8005DF40(0, 0x3C);
             gLookatEyeZ = 352.0f;
             Sound_PlaySfx(SFX_CROUD_CHATTER);
@@ -1513,19 +1513,19 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
                 func_8005DF5C(9);
                 D_800D5830 = 48;
                 D_800D5834 = -2;
-                gActors[0x50].positionHistory[1].raw = 1;
+                gActors[0x50].positionHistory[1] = 1;
             }
             break;
 
         case 2:
             if (D_800D5824 == 0x4000) {
-                gActors[0x50].positionHistory[1].raw = 6;
+                gActors[0x50].positionHistory[1] = 6;
             }
 
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x12C;
-                gActors[0x50].positionHistory[1].raw = 0;
+                gActors[0x50].positionHistory[1] = 0;
                 Sound_PlaySfx(SFX_CROUD_CHEER);
                 Sound_StopSfx(SFX_CROUD_CHATTER);
                 func_801B3F84_7BFED4(1);
@@ -1536,7 +1536,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             D_801B4B64_7C0AB4--;
             if (D_801B4B64_7C0AB4 < 0) {
                 gActors[actor_index].state = gActors[actor_index].state + 1;
-                gActors[0x50].positionHistory[1].raw = 1;
+                gActors[0x50].positionHistory[1] = 1;
                 func_8005DF5C(0xA);
                 D_800D5830 = 48;
                 D_800D5834 = -2;
@@ -1546,7 +1546,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
 
         case 4:
             if (D_800D5824 == 0x4000) {
-                gActors[0x50].positionHistory[1].raw = 6;
+                gActors[0x50].positionHistory[1] = 6;
             }
 
             if (D_800D582C >= 2) {
@@ -1563,7 +1563,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (D_801B4B64_7C0AB4 < 0) {
                 if (func_8005DEFC() == 0) {
                     gActors[actor_index].state++;
-                    gActors[0x52].positionHistory[1].raw = 5;
+                    gActors[0x52].positionHistory[1] = 5;
                 }
             }
             break;
@@ -1582,7 +1582,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].positionHistory[1].raw = 6;
+                gActors[0x52].positionHistory[1] = 6;
             }
             break;
 
@@ -1600,7 +1600,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].positionHistory[1].raw = 0;
+                gActors[0x52].positionHistory[1] = 0;
             }
             break;
 
@@ -1625,7 +1625,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             D_801B4B64_7C0AB4--;
             if (D_801B4B64_7C0AB4 < 0) {
                 gActors[actor_index].state = gActors[actor_index].state + 1;
-                gActors[0x52].positionHistory[1].raw = 1;
+                gActors[0x52].positionHistory[1] = 1;
                 func_8005DF5C(0xE);
                 D_800D5830 = 96;
                 D_800D5834 = -2;
@@ -1636,7 +1636,7 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
                 D_801B4B64_7C0AB4 = 0x1E;
-                gActors[0x52].positionHistory[1].raw = 0;
+                gActors[0x52].positionHistory[1] = 0;
             }
             break;
 
@@ -1664,14 +1664,14 @@ void func_801B3FC8_7BFF18(u16 actor_index) {
                 func_8005DF5C(0x10);
                 D_800D5830 = 96;
                 D_800D5834 = -2;
-                gActors[0x52].positionHistory[1].raw = 1;
+                gActors[0x52].positionHistory[1] = 1;
             }
             break;
 
         case 17:
             if (func_8005DEFC() == 0) {
                 gActors[actor_index].state++;
-                gActors[0x52].positionHistory[1].raw = 6;
+                gActors[0x52].positionHistory[1] = 6;
             }
             break;
 

--- a/src/overlay_3/overlay_7C0AB0/7C0B20.c
+++ b/src/overlay_3/overlay_7C0AB0/7C0B20.c
@@ -749,7 +749,7 @@ void func_801B224C_7C246C(u16 actor_index) {
         switch (gActors[actor_index].unk_174) {
         case 0:
             gActors[actor_index].unk_174++;
-            gActors[actor_index].unk_184_s16[0] = gScreenPosCurrentX.whole + (gActors + 0)->posX.whole;
+            gActors[actor_index].unk_184_s16[0] = gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0];
             func_800734C4(actor_index, 0x28);
             gActors[actor_index].unk_170 = Rand() & 7;
             break;
@@ -2266,7 +2266,6 @@ void func_801B616C_7C638C(u16 arg0) {
         // fakematch
         if ((gActors[arg0].posZ.whole + arg0) && (gActors[arg0].posZ.whole + arg0)) {
         }
-        //
 
         gActors[arg0].posX.whole = D_801B66BC_7C68DC[gActors[arg0].var_0D8].positionX;
         gActors[arg0].posY.whole = D_801B66BC_7C68DC[gActors[arg0].var_0D8].positionY;

--- a/src/overlay_4/overlay_7C6AB0/7C6AE0.c
+++ b/src/overlay_4/overlay_7C6AB0/7C6AE0.c
@@ -2043,16 +2043,14 @@ void func_801BAB34_7C7D14(void) {
             D_800D28F8--;
 
             if (D_800D28F8 == 0x1E) {
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1002; 
+                gActors[0x50].positionHistory[1].raw = 0x1002;
             }
 
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(2);
 
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1001; 
+                gActors[0x50].positionHistory[1].raw = 0x1001;
 
                 Sound_PlayMusic(BGM_OUT);
             }
@@ -2075,8 +2073,7 @@ void func_801BAB34_7C7D14(void) {
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(3);
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1001;
+                gActors[0x50].positionHistory[1].raw = 0x1001;
             }
 
             Cutscene_CheckSkipInput();
@@ -2097,10 +2094,8 @@ void func_801BAB34_7C7D14(void) {
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(4);
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1001;
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1001;
+                gActors[0x50].positionHistory[1].raw = 0x1001;
+                gActors[0x50].positionHistory[1].raw = 0x1001;
             }
 
             Cutscene_CheckSkipInput();
@@ -2123,8 +2118,7 @@ void func_801BAB34_7C7D14(void) {
                 Sound_PlaySfx(SFX_MARINA_STOP);
                 func_8005DF5C(5);
 
-                // FAKEMATCH
-                *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1100;
+                gActors[0x50].positionHistory[1].raw = 0x1100;
             }
 
             Cutscene_CheckSkipInput();
@@ -2224,8 +2218,7 @@ void func_801BAB34_7C7D14(void) {
             D_800BE544 = 0x8000;
             Sound_PlayMusic(BGM_OUT);
 
-            // FAKEMATCH
-            *(&gPlayerActor.unk_174 + 0x1FE0) = 0x1100;
+            gActors[0x50].positionHistory[1].raw = 0x1100;
             break;
 
         case 0x1001:
@@ -2339,13 +2332,10 @@ void func_801BB310_7C84F0(void) {
 }
 
 void func_801BB6AC_7C888C(u16 arg0) {
-    s32* unk_174 = &gActors[0x50].unk_174;
-    s32 stride = sizeof(Actor) / sizeof(*unk_174);
-
-    unk_174[stride * 0] = arg0;
-    unk_174[stride * 1] = arg0;
-    unk_174[stride * 2] = arg0;
-    unk_174[stride * 3] = arg0;
+    gActors[0x50].positionHistory[1].raw = arg0;
+    gActors[0x51].positionHistory[1].raw = arg0;
+    gActors[0x52].positionHistory[1].raw = arg0;
+    gActors[0x53].positionHistory[1].raw = arg0;
 }
 
 void func_801BB6D0_7C88B0(void) {
@@ -2427,7 +2417,7 @@ void func_801BB6D0_7C88B0(void) {
                         break;
 
                     case 0xC:
-                        *(&gPlayerActor.unk_174 + 0x1FE0) = 1; // FAKEMATCH
+                        gActors[0x50].positionHistory[1].raw = 1;
                         break;
 
                     case 0xE:

--- a/src/overlay_4/overlay_7C6AB0/7C6AE0.c
+++ b/src/overlay_4/overlay_7C6AB0/7C6AE0.c
@@ -2043,14 +2043,14 @@ void func_801BAB34_7C7D14(void) {
             D_800D28F8--;
 
             if (D_800D28F8 == 0x1E) {
-                gActors[0x50].positionHistory[1].raw = 0x1002;
+                gActors[0x50].positionHistory[1] = 0x1002;
             }
 
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(2);
 
-                gActors[0x50].positionHistory[1].raw = 0x1001;
+                gActors[0x50].positionHistory[1] = 0x1001;
 
                 Sound_PlayMusic(BGM_OUT);
             }
@@ -2073,7 +2073,7 @@ void func_801BAB34_7C7D14(void) {
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(3);
-                gActors[0x50].positionHistory[1].raw = 0x1001;
+                gActors[0x50].positionHistory[1] = 0x1001;
             }
 
             Cutscene_CheckSkipInput();
@@ -2094,8 +2094,8 @@ void func_801BAB34_7C7D14(void) {
             if (D_800D28F8 < 0) {
                 gStageState++;
                 func_8005DF5C(4);
-                gActors[0x50].positionHistory[1].raw = 0x1001;
-                gActors[0x50].positionHistory[1].raw = 0x1001;
+                gActors[0x50].positionHistory[1] = 0x1001;
+                gActors[0x50].positionHistory[1] = 0x1001;
             }
 
             Cutscene_CheckSkipInput();
@@ -2118,7 +2118,7 @@ void func_801BAB34_7C7D14(void) {
                 Sound_PlaySfx(SFX_MARINA_STOP);
                 func_8005DF5C(5);
 
-                gActors[0x50].positionHistory[1].raw = 0x1100;
+                gActors[0x50].positionHistory[1] = 0x1100;
             }
 
             Cutscene_CheckSkipInput();
@@ -2218,7 +2218,7 @@ void func_801BAB34_7C7D14(void) {
             D_800BE544 = 0x8000;
             Sound_PlayMusic(BGM_OUT);
 
-            gActors[0x50].positionHistory[1].raw = 0x1100;
+            gActors[0x50].positionHistory[1] = 0x1100;
             break;
 
         case 0x1001:
@@ -2332,10 +2332,10 @@ void func_801BB310_7C84F0(void) {
 }
 
 void func_801BB6AC_7C888C(u16 arg0) {
-    gActors[0x50].positionHistory[1].raw = arg0;
-    gActors[0x51].positionHistory[1].raw = arg0;
-    gActors[0x52].positionHistory[1].raw = arg0;
-    gActors[0x53].positionHistory[1].raw = arg0;
+    gActors[0x50].positionHistory[1] = arg0;
+    gActors[0x51].positionHistory[1] = arg0;
+    gActors[0x52].positionHistory[1] = arg0;
+    gActors[0x53].positionHistory[1] = arg0;
 }
 
 void func_801BB6D0_7C88B0(void) {
@@ -2417,7 +2417,7 @@ void func_801BB6D0_7C88B0(void) {
                         break;
 
                     case 0xC:
-                        gActors[0x50].positionHistory[1].raw = 1;
+                        gActors[0x50].positionHistory[1] = 1;
                         break;
 
                     case 0xE:

--- a/src/overlay_4/overlay_7CE060/7CE090.c
+++ b/src/overlay_4/overlay_7CE060/7CE090.c
@@ -1313,9 +1313,7 @@ void func_801B9B08_7CE298(void) {
 // check if player fell in lava, zero postiob vars if so.
 void func_801B9B94_7CE324(void) {
     if (func_801B9900_7CE090() != 0) {
-        // FAKEMATCH
-        gPlayerVelYMirror.raw = (gPlayerVelYMirror.raw * 0) + (gPlayerActor.velocityX.raw = (((gPlayerActor.velocityY.raw = 0) & 0xFFFFFFFFFFFFFFFFULL)));
-        gPlayerVelXMirror.raw = 0;
+        gPlayerVelXMirror.raw = gPlayerVelYMirror.raw = gPlayerActor.velocityX.raw = gPlayerActor.velocityY.raw = 0;
         func_801B9A0C_7CE19C(gStageState + 1);
     }
 }

--- a/src/overlay_4/overlay_7D40C0/7D40F0.c
+++ b/src/overlay_4/overlay_7D40C0/7D40F0.c
@@ -2009,7 +2009,7 @@ void func_801BAF14_7D5704(void) {
             }
 
             func_801BAC6C_7D545C();
-            // required to produce fixed address within gActors
+            // fakematch
             if ((gScreenPosCurrentX.whole + (gActors + 0x31)->posX.whole) >= 0x901) {
                 gStageState = 4;
             }
@@ -2028,7 +2028,7 @@ void func_801BAF14_7D5704(void) {
             }
 
             func_801BAC6C_7D545C();
-            // required to produce fixed address within gActors
+            // fakematch
             if ((gScreenPosCurrentX.whole + (gActors + 0x31)->posX.whole) >= 0xE81) {
                 gStageState = 6;
             }

--- a/src/overlay_4/overlay_7E2A30/7E2A60.c
+++ b/src/overlay_4/overlay_7E2A30/7E2A60.c
@@ -790,15 +790,15 @@ void func_801B9E74_7E2FD4(void) {
         case 6:
             switch (gStageTimer) {
                 case 0:
-                    if (((gScreenPosCurrentX.whole + (gActors + 0)->posX.whole) >= 0x940) &&
-                        ((gScreenPosCurrentX.whole + (gActors + 0x40)->posX.whole) >= 0x940)) {
+                    if (((gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0]) >= 0x940) &&
+                        ((gActors[0x40].posX.whole + gScreenPosCurrentX.parts[0]) >= 0x940)) {
                         gStageTimer++;
                     }
                     break;
 
                 case 1:
-                    if (((gScreenPosCurrentX.whole + (gActors + 0)->posX.whole) >= 0x1430) &&
-                        ((gScreenPosCurrentX.whole + (gActors + 0x40)->posX.whole) >= 0x1430)) {
+                    if (((gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0]) >= 0x1430) &&
+                        ((gActors[0x40].posX.whole + gScreenPosCurrentX.parts[0]) >= 0x1430)) {
                         gStageTimer++;
                     }
                     break;
@@ -809,10 +809,10 @@ void func_801B9E74_7E2FD4(void) {
 
             func_801B9D78_7E2ED8();
 
-            if ((gScreenPosCurrentX.whole + (gActors + 0)->posX.whole) >= 0x2070) {
+            if ((gPlayerActor.posX.whole + gScreenPosCurrentX.parts[0]) >= 0x2070) {
                 gPlayerActor.flags_098 |= ACTOR_FLAG3_UNK16;
 
-                if ((gScreenPosCurrentX.whole + (gActors + 0x41)->posX.whole) < 0x1FD8) {
+                if ((gActors[0x41].posX.whole + gScreenPosCurrentX.parts[0]) < 0x1FD8) {
                     gActors[0x40].flags = 0;
                     gActors[0x41].flags = 0;
                 }
@@ -824,8 +824,8 @@ void func_801B9E74_7E2FD4(void) {
                 gScreenBoundX0.whole = D_800D2920;
                 D_800D28F8 = 4;
 
-                if (((gScreenPosCurrentX.whole + (gActors + 0x41)->posX.whole) >= 0x2000) &&
-                    ((gScreenPosCurrentY.whole + (gActors + 0x41)->posY.whole) >= 0x140) &&
+                if (((gActors[0x41].posX.whole + gScreenPosCurrentX.parts[0]) >= 0x2000) &&
+                    ((gActors[0x41].posY.whole + gScreenPosCurrentY.parts[0]) >= 0x140) &&
                     (gActors[0x40].flags & 2)) {
                     gStageState = 7;
                 }
@@ -891,7 +891,7 @@ void func_801B9E74_7E2FD4(void) {
     Camera_UpdateViewBounds();
 
     if (gActors[0x40].flags & 2) {
-        if ((gScreenPosCurrentY.whole + (gActors + 0x40)->posY.whole) < 0x81) {
+        if ((gActors[0x40].posY.whole + gScreenPosCurrentY.parts[0]) < 0x81) {
             gActors[0x40].flags = 0;
             gActors[0x41].flags = 0;
         }

--- a/versions/us1/us1_report.json
+++ b/versions/us1/us1_report.json
@@ -1,13 +1,13 @@
 {
   "measures": {
-    "fuzzy_match_percent": 53.46607,
+    "fuzzy_match_percent": 53.520626,
     "total_code": "1994304",
-    "matched_code": "1066276",
-    "matched_code_percent": 53.46607,
+    "matched_code": "1067364",
+    "matched_code_percent": 53.520626,
     "matched_data_percent": 100.0,
     "total_functions": 4707,
-    "matched_functions": 3165,
-    "matched_functions_percent": 67.24028,
+    "matched_functions": 3166,
+    "matched_functions_percent": 67.26152,
     "complete_data_percent": 100.0,
     "total_units": 391
   },
@@ -7009,21 +7009,21 @@
     {
       "name": "42E90",
       "measures": {
-        "fuzzy_match_percent": 58.787876,
+        "fuzzy_match_percent": 100.0,
         "total_code": "2640",
-        "matched_code": "1552",
-        "matched_code_percent": 58.787876,
+        "matched_code": "2640",
+        "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 19,
-        "matched_functions": 18,
-        "matched_functions_percent": 94.73685,
+        "matched_functions": 19,
+        "matched_functions_percent": 100.0,
         "total_units": 1
       },
       "sections": [
         {
           "name": ".text",
           "size": "2640",
-          "fuzzy_match_percent": 58.787876,
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147754640"
           }
@@ -7127,6 +7127,7 @@
         {
           "name": "func_800423A0",
           "size": "1088",
+          "fuzzy_match_percent": 100.0,
           "metadata": {
             "virtual_address": "2147754912"
           }
@@ -50033,14 +50034,14 @@
       "id": "segment_main",
       "name": "Main segment",
       "measures": {
-        "fuzzy_match_percent": 99.85911,
+        "fuzzy_match_percent": 100.0,
         "total_code": "772208",
-        "matched_code": "771120",
-        "matched_code_percent": 99.85911,
+        "matched_code": "772208",
+        "matched_code_percent": 100.0,
         "matched_data_percent": 100.0,
         "total_functions": 2162,
-        "matched_functions": 2161,
-        "matched_functions_percent": 99.95375,
+        "matched_functions": 2162,
+        "matched_functions_percent": 100.0,
         "complete_data_percent": 100.0,
         "total_units": 255
       }


### PR DESCRIPTION
This matches the last function in the main segment. We thought it required `gScreenPosCurrent[2]` over `gScreenPosCurrentX` and `gScreenPosCurrentY`, but `gScreenPosCurrent[2]` didn't seem to match in most instances.
I discovered that the following (adding `parts`) ended up working:
```c
typedef union {
    /* 0x00 */ s32 raw;
    /* 0x00 */ s16 parts[2]; // 0 = whole, 1 = frac
    struct {
    /* 0x00 */ s16 whole;
    /* 0x02 */ s16 frac;
    };
} FixedCoord;
```
This also helped solve and/or simplify some existing fakematches which weren't related to `gScreenPosCurrent...`.
I also updated Actor with an array at 170 which was needed for a good match; this also solved some really oddball address folding, which resulted in pointer-arithmetic fakematches in the past.

Finally, I noticed some fixed unit stuff around the code I was editing and cleaned that up, so there's some extra macro use.